### PR TITLE
Add root API discovery route and launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "eugene-main",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["eugene_server.py"],
+      "port": 8000
+    },
+    {
+      "name": "eugene-api-server",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8001"],
+      "port": 8001
+    },
+    {
+      "name": "eugene-api-legacy",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8002"],
+      "port": 8002
+    }
+  ]
+}

--- a/eugene_server.py
+++ b/eugene_server.py
@@ -82,6 +82,32 @@ def _build_mcp(include_rest: bool = False):
         from starlette.requests import Request
         from starlette.responses import JSONResponse
 
+        @mcp.custom_route("/", methods=["GET"])
+        async def root(request: Request) -> JSONResponse:
+            return JSONResponse({
+                "service": "Eugene Intelligence",
+                "version": "0.5.0",
+                "status": "ok",
+                "docs": {
+                    "health": "/health",
+                    "capabilities": "/v1/capabilities",
+                    "concepts": "/v1/concepts",
+                },
+                "endpoints": {
+                    "sec_data": "/v1/sec/{identifier}?extract=financials",
+                    "economics": "/v1/economics/{category}",
+                    "prices": "/v1/sec/{ticker}/prices",
+                    "profile": "/v1/sec/{ticker}/profile",
+                    "earnings": "/v1/sec/{ticker}/earnings",
+                    "estimates": "/v1/sec/{ticker}/estimates",
+                    "news": "/v1/sec/{ticker}/news",
+                },
+                "mcp": {
+                    "streamable_http": "/mcp",
+                    "sse": "/sse",
+                },
+            })
+
         @mcp.custom_route("/health", methods=["GET"])
         async def health(request: Request) -> JSONResponse:
             return JSONResponse({"status": "ok", "version": "0.5.0"})


### PR DESCRIPTION
## Summary
- Add root `/` endpoint to `eugene_server.py` — returns service info, all available REST endpoints, and MCP connection paths (fixes "Not Found" on server landing page)
- Add `.claude/launch.json` with dev server configurations for all three servers (eugene-main, eugene-api-server, eugene-api-legacy)

## Test plan
- [ ] Visit `http://localhost:8000/` and verify JSON discovery response
- [ ] Verify `/health` still returns `{"status": "ok"}`
- [ ] Confirm all listed endpoints in the discovery response are reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)