### PR TITLE
Phase 3: Tests, async HTTP, persistent disk cache

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,21 +3,9 @@
   "configurations": [
     {
       "name": "eugene-main",
-      "runtimeExecutable": "python",
-      "runtimeArgs": ["eugene_server.py"],
+      "runtimeExecutable": "/Users/nzubechukwuanyiam/Desktop/eugene/venv/bin/python3",
+      "runtimeArgs": ["/Users/nzubechukwuanyiam/Desktop/eugene/eugene_server.py"],
       "port": 8000
-    },
-    {
-      "name": "eugene-api-server",
-      "runtimeExecutable": "python",
-      "runtimeArgs": ["-m", "uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8001"],
-      "port": 8001
-    },
-    {
-      "name": "eugene-api-legacy",
-      "runtimeExecutable": "python",
-      "runtimeArgs": ["-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8002"],
-      "port": 8002
     }
   ]
 }

--- a/eugene/cache.py
+++ b/eugene/cache.py
@@ -1,10 +1,27 @@
-"""In-memory TTL cache with size eviction. Replace with Redis when needed."""
-import time
+"""In-memory TTL cache (L1) + optional persistent disk cache (L2).
+
+L1 = fast in-process dict, evicted on restart.
+L2 = JSON files under ``~/.cache/eugene/``, survives restarts.
+
+Usage:
+    @cached(ttl=3600)                          # L1 only
+    @cached(ttl=3600, disk=True, disk_ttl=86400)  # L1 + L2
+"""
 import hashlib
 import json
+import logging
+import os
+import shutil
+import time
 from functools import wraps
+from pathlib import Path
 
-_CACHE = {}
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# L1 — in-memory TTL cache
+# ---------------------------------------------------------------------------
+_CACHE: dict = {}
 MAX_SIZE = 1000
 
 
@@ -25,30 +42,187 @@ def _evict_oldest(count: int = 1):
         del _CACHE[k]
 
 
-def cached(ttl: int = 3600):
-    """Decorator: cache function result for `ttl` seconds."""
+def cache_clear():
+    _CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# L2 — persistent disk cache
+# ---------------------------------------------------------------------------
+_DEFAULT_CACHE_DIR = os.path.join(Path.home(), ".cache", "eugene")
+_MAX_DISK_ENTRIES = 5000
+
+
+class DiskCache:
+    """JSON-file disk cache with TTL expiry and size eviction.
+
+    Each entry is a JSON file named by SHA-256 of the key.  Metadata
+    (stored_at, expires_at) lives inside the file alongside the payload.
+    """
+
+    def __init__(self, cache_dir: str | None = None, max_entries: int = _MAX_DISK_ENTRIES):
+        self.cache_dir = Path(cache_dir or _DEFAULT_CACHE_DIR)
+        self.max_entries = max_entries
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _hash_key(key: str) -> str:
+        return hashlib.sha256(key.encode()).hexdigest()
+
+    def _path(self, hashed: str) -> Path:
+        return self.cache_dir / f"{hashed}.json"
+
+    # -- public API -------------------------------------------------------
+
+    def get(self, key: str):
+        """Return cached value or ``None`` if missing / expired."""
+        hashed = self._hash_key(key)
+        path = self._path(hashed)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            if time.time() >= data["expires_at"]:
+                path.unlink(missing_ok=True)
+                return None
+            return data["value"]
+        except (json.JSONDecodeError, KeyError, OSError):
+            path.unlink(missing_ok=True)
+            return None
+
+    def set(self, key: str, value, ttl: int = 86400):
+        """Store *value* (must be JSON-serialisable) with TTL seconds."""
+        hashed = self._hash_key(key)
+        path = self._path(hashed)
+        now = time.time()
+        payload = {
+            "key": key,
+            "stored_at": now,
+            "expires_at": now + ttl,
+            "value": value,
+        }
+        try:
+            path.write_text(json.dumps(payload, default=str))
+        except OSError:
+            logger.warning("disk cache write failed for %s", key)
+        # Size eviction
+        self._maybe_evict()
+
+    def delete(self, key: str):
+        """Remove a single entry."""
+        hashed = self._hash_key(key)
+        self._path(hashed).unlink(missing_ok=True)
+
+    def clear(self):
+        """Remove all cache files."""
+        if self.cache_dir.exists():
+            shutil.rmtree(self.cache_dir)
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def evict_expired(self):
+        """Scan and remove expired entries."""
+        now = time.time()
+        removed = 0
+        for path in self.cache_dir.glob("*.json"):
+            try:
+                data = json.loads(path.read_text())
+                if now >= data.get("expires_at", 0):
+                    path.unlink(missing_ok=True)
+                    removed += 1
+            except (json.JSONDecodeError, KeyError, OSError):
+                path.unlink(missing_ok=True)
+                removed += 1
+        return removed
+
+    def _maybe_evict(self):
+        """If over max_entries, remove oldest 10%."""
+        entries = list(self.cache_dir.glob("*.json"))
+        if len(entries) <= self.max_entries:
+            return
+        # Sort by mtime (oldest first)
+        entries.sort(key=lambda p: p.stat().st_mtime)
+        to_remove = max(1, len(entries) // 10)
+        for path in entries[:to_remove]:
+            path.unlink(missing_ok=True)
+
+    def size(self) -> int:
+        """Return number of cached entries."""
+        return len(list(self.cache_dir.glob("*.json")))
+
+
+# Shared singleton instance
+_disk_cache: DiskCache | None = None
+
+
+def get_disk_cache() -> DiskCache:
+    """Return the shared DiskCache singleton."""
+    global _disk_cache
+    if _disk_cache is None:
+        _disk_cache = DiskCache()
+    return _disk_cache
+
+
+# ---------------------------------------------------------------------------
+# Decorator — supports L1 only or L1 + L2
+# ---------------------------------------------------------------------------
+def cached(ttl: int = 3600, disk: bool = False, disk_ttl: int = 86400):
+    """Decorator: cache function result with optional L2 disk backing.
+
+    Parameters
+    ----------
+    ttl : int
+        L1 (in-memory) TTL in seconds.
+    disk : bool
+        If True, also cache on disk for persistence across restarts.
+    disk_ttl : int
+        L2 (disk) TTL in seconds.  Defaults to 1 day.
+    """
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             key = f"{fn.__name__}:{hashlib.md5(json.dumps([args, kwargs], default=str).encode()).hexdigest()}"
             now = time.time()
+
+            # --- L1 check ---
             if key in _CACHE:
                 val, expires = _CACHE[key]
                 if now < expires:
                     return val
-                # Expired — remove stale entry
                 del _CACHE[key]
+
+            # --- L2 check ---
+            if disk:
+                dc = get_disk_cache()
+                disk_val = dc.get(key)
+                if disk_val is not None:
+                    # Promote to L1
+                    if len(_CACHE) >= MAX_SIZE:
+                        _evict_expired()
+                    if len(_CACHE) >= MAX_SIZE:
+                        _evict_oldest(MAX_SIZE // 10)
+                    _CACHE[key] = (disk_val, now + ttl)
+                    return disk_val
+
+            # --- Miss: call function ---
             result = fn(*args, **kwargs)
-            # Evict before inserting if at capacity
+
+            # Store in L1
             if len(_CACHE) >= MAX_SIZE:
                 _evict_expired()
             if len(_CACHE) >= MAX_SIZE:
                 _evict_oldest(MAX_SIZE // 10)
             _CACHE[key] = (result, now + ttl)
+
+            # Store in L2
+            if disk:
+                dc = get_disk_cache()
+                try:
+                    dc.set(key, result, ttl=disk_ttl)
+                except Exception:
+                    logger.warning("disk cache write failed for %s", fn.__name__)
+
             return result
         return wrapper
     return decorator
-
-
-def cache_clear():
-    _CACHE.clear()

--- a/eugene/rate_limit.py
+++ b/eugene/rate_limit.py
@@ -1,4 +1,5 @@
 """Simple token-bucket rate limiter per data source."""
+import asyncio
 import time
 import threading
 
@@ -28,7 +29,38 @@ class RateLimiter:
             self._last_call = time.monotonic()
 
 
-# Pre-configured limiters for each source
+class AsyncRateLimiter:
+    """Async-compatible rate limiter using token-bucket algorithm.
+
+    Usage:
+        limiter = AsyncRateLimiter(max_per_second=10)
+        await limiter.acquire()  # awaits until a slot is available
+        async with httpx.AsyncClient() as client:
+            ...
+    """
+
+    def __init__(self, max_per_second: float = 10.0):
+        self.max_per_second = max_per_second
+        self.min_interval = 1.0 / max_per_second
+        self._lock = asyncio.Lock()
+        self._last_call = 0.0
+
+    async def acquire(self):
+        """Await until rate limit allows the next request."""
+        async with self._lock:
+            now = asyncio.get_event_loop().time()
+            elapsed = now - self._last_call
+            if elapsed < self.min_interval:
+                await asyncio.sleep(self.min_interval - elapsed)
+            self._last_call = asyncio.get_event_loop().time()
+
+
+# Pre-configured sync limiters for each source
 SEC_LIMITER = RateLimiter(max_per_second=9.0)   # SEC limit is 10/s, stay under
 FMP_LIMITER = RateLimiter(max_per_second=5.0)   # conservative for free tier
 FRED_LIMITER = RateLimiter(max_per_second=5.0)
+
+# Pre-configured async limiters for each source
+ASYNC_SEC_LIMITER = AsyncRateLimiter(max_per_second=9.0)
+ASYNC_FMP_LIMITER = AsyncRateLimiter(max_per_second=5.0)
+ASYNC_FRED_LIMITER = AsyncRateLimiter(max_per_second=5.0)

--- a/eugene/sources/sec_api.py
+++ b/eugene/sources/sec_api.py
@@ -16,7 +16,7 @@ BASE = "https://data.sec.gov"
 EFTS_BASE = "https://efts.sec.gov"
 
 
-@cached(ttl=86400)
+@cached(ttl=86400, disk=True, disk_ttl=604800)
 def fetch_tickers() -> dict:
     """SEC company tickers JSON → {ticker: {cik_str, title}}."""
     SEC_LIMITER.acquire()
@@ -28,7 +28,7 @@ def fetch_tickers() -> dict:
     return r.json()
 
 
-@cached(ttl=3600)
+@cached(ttl=3600, disk=True, disk_ttl=86400)
 def fetch_submissions(cik: str) -> dict:
     """SEC submissions (filings metadata + company info)."""
     SEC_LIMITER.acquire()
@@ -41,7 +41,7 @@ def fetch_submissions(cik: str) -> dict:
     return r.json()
 
 
-@cached(ttl=3600)
+@cached(ttl=3600, disk=True, disk_ttl=604800)
 def fetch_companyfacts(cik: str) -> dict:
     """SEC XBRL companyfacts (all concepts, all periods)."""
     SEC_LIMITER.acquire()

--- a/eugene_server.py
+++ b/eugene_server.py
@@ -1,6 +1,9 @@
 """
-Eugene Intelligence v0.6 — Unified SEC Data Server
+Eugene Intelligence v0.8 — Unified SEC Data Server
 FastAPI REST + MCP (stdio, SSE, streamable HTTP) in one file.
+
+All sync data-source calls are wrapped in ``asyncio.to_thread()`` so
+the async event loop is never blocked by network I/O.
 
 Usage:
   python eugene_server.py           -> API + MCP on port 8000
@@ -21,6 +24,7 @@ from eugene.sources.fmp import (
     get_historical_bars, get_screener, get_crypto_quote,
 )
 from eugene.auth import require_api_key
+from eugene.cache import get_disk_cache
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +235,9 @@ def _build_mcp(include_rest: bool = False):
                 "to": request.query_params.get("to"),
                 "limit": limit,
             }
-            return JSONResponse(query(identifier, extract, **{k: v for k, v in params.items() if v is not None}))
+            clean = {k: v for k, v in params.items() if v is not None}
+            result = await asyncio.to_thread(query, identifier, extract, **clean)
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/economics/{category}", methods=["GET"])
         @require_api_key
@@ -239,10 +245,13 @@ def _build_mcp(include_rest: bool = False):
             category = request.path_params["category"]
             series_param = request.query_params.get("series")
             if series_param:
-                return JSONResponse(get_series(series_param))
+                result = await asyncio.to_thread(get_series, series_param)
+                return JSONResponse(result)
             if category == "all":
-                return JSONResponse(get_all())
-            return JSONResponse(get_category(category))
+                result = await asyncio.to_thread(get_all)
+                return JSONResponse(result)
+            result = await asyncio.to_thread(get_category, category)
+            return JSONResponse(result)
 
         # --- v0.6 convenience routes ---
 
@@ -268,9 +277,11 @@ def _build_mcp(include_rest: bool = False):
             limit = _safe_int(p.get("limit", "50"), 50, "limit")
             if isinstance(limit, JSONResponse):
                 return limit
-            return JSONResponse(get_screener(
+            result = await asyncio.to_thread(
+                get_screener,
                 **parsed, sector=p.get("sector"), country=p.get("country"), limit=limit,
-            ))
+            )
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/crypto/{symbol}", methods=["GET"])
         @require_api_key
@@ -278,18 +289,22 @@ def _build_mcp(include_rest: bool = False):
             symbol = request.path_params["symbol"]
             interval = request.query_params.get("interval", "quote")
             if interval == "quote":
-                return JSONResponse(get_crypto_quote(symbol))
-            return JSONResponse(get_historical_bars(symbol, interval=interval))
+                result = await asyncio.to_thread(get_crypto_quote, symbol)
+                return JSONResponse(result)
+            result = await asyncio.to_thread(get_historical_bars, symbol, interval=interval)
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/prices", methods=["GET"])
         @require_api_key
         async def prices_compat(request: Request) -> JSONResponse:
-            return JSONResponse(get_price(request.path_params["ticker"]))
+            result = await asyncio.to_thread(get_price, request.path_params["ticker"])
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/profile", methods=["GET"])
         @require_api_key
         async def profile_compat(request: Request) -> JSONResponse:
-            return JSONResponse(get_profile(request.path_params["ticker"]))
+            result = await asyncio.to_thread(get_profile, request.path_params["ticker"])
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/ohlcv", methods=["GET"])
         @require_api_key
@@ -298,22 +313,26 @@ def _build_mcp(include_rest: bool = False):
             interval = request.query_params.get("interval", "daily")
             from_date = request.query_params.get("from")
             to_date = request.query_params.get("to")
-            return JSONResponse(get_historical_bars(ticker, interval, from_date, to_date))
+            result = await asyncio.to_thread(get_historical_bars, ticker, interval, from_date, to_date)
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/earnings", methods=["GET"])
         @require_api_key
         async def earnings_compat(request: Request) -> JSONResponse:
-            return JSONResponse(get_earnings(request.path_params["ticker"]))
+            result = await asyncio.to_thread(get_earnings, request.path_params["ticker"])
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/estimates", methods=["GET"])
         @require_api_key
         async def estimates_compat(request: Request) -> JSONResponse:
-            return JSONResponse(get_estimates(request.path_params["ticker"]))
+            result = await asyncio.to_thread(get_estimates, request.path_params["ticker"])
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{ticker}/news", methods=["GET"])
         @require_api_key
         async def news_compat(request: Request) -> JSONResponse:
-            return JSONResponse(get_news(request.path_params["ticker"]))
+            result = await asyncio.to_thread(get_news, request.path_params["ticker"])
+            return JSONResponse(result)
 
         @mcp.custom_route("/v1/sec/{identifier}/export", methods=["GET"])
         @require_api_key
@@ -330,13 +349,14 @@ def _build_mcp(include_rest: bool = False):
             }
             if fmt == "csv":
                 from eugene.handlers.export import export_financials_csv
-                csv_data = export_financials_csv(identifier, extract, **params)
+                csv_data = await asyncio.to_thread(export_financials_csv, identifier, extract, **params)
                 return Response(
                     content=csv_data, media_type="text/csv",
                     headers={"Content-Disposition": f"attachment; filename={identifier}_{extract}.csv"},
                 )
             else:
-                return JSONResponse(query(identifier, extract, **params))
+                result = await asyncio.to_thread(query, identifier, extract, **params)
+                return JSONResponse(result)
 
         @mcp.custom_route("/v1/stream/filings", methods=["GET"])
         @require_api_key
@@ -350,7 +370,7 @@ def _build_mcp(include_rest: bool = False):
                 seen = set()
                 while True:
                     try:
-                        filings = get_recent_filings(minutes=2)
+                        filings = await asyncio.to_thread(get_recent_filings, minutes=2)
                         for filing in filings:
                             fid = filing.get("accession_number", filing.get("url", ""))
                             if fid in seen:
@@ -398,6 +418,13 @@ def run_api():
     mcp = _build_mcp(include_rest=True)
     mcp.settings.port = port
     mcp.settings.host = "0.0.0.0"
+
+    # Warm up disk cache (evict expired entries on startup)
+    dc = get_disk_cache()
+    expired = dc.evict_expired()
+    if expired:
+        logging.info(f"Disk cache: evicted {expired} expired entries")
+    logging.info(f"Disk cache: {dc.size()} entries in {dc.cache_dir}")
 
     logging.info(f"Starting Eugene v{VERSION} on port {port}")
     logging.info(f"REST API: http://0.0.0.0:{port}/health")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,134 @@
+"""Tests for async rate limiter and asyncio.to_thread wrapping."""
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from eugene.rate_limit import AsyncRateLimiter, RateLimiter
+
+
+# ---------------------------------------------------------------------------
+# AsyncRateLimiter
+# ---------------------------------------------------------------------------
+class TestAsyncRateLimiter:
+    @pytest.mark.asyncio
+    async def test_basic_acquire(self):
+        limiter = AsyncRateLimiter(max_per_second=100.0)
+        await limiter.acquire()
+        assert limiter._last_call > 0
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting(self):
+        limiter = AsyncRateLimiter(max_per_second=10.0)
+        start = time.monotonic()
+        for _ in range(3):
+            await limiter.acquire()
+        elapsed = time.monotonic() - start
+        # 3 calls at 10/s → need at least ~0.2s gap (2 intervals)
+        assert elapsed >= 0.15
+
+    @pytest.mark.asyncio
+    async def test_min_interval(self):
+        limiter = AsyncRateLimiter(max_per_second=5.0)
+        assert limiter.min_interval == pytest.approx(0.2)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_acquire(self):
+        """Multiple coroutines should be serialised by the lock."""
+        limiter = AsyncRateLimiter(max_per_second=50.0)
+        results = []
+
+        async def worker(n):
+            await limiter.acquire()
+            results.append(n)
+
+        await asyncio.gather(*[worker(i) for i in range(5)])
+        assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# Sync RateLimiter (basic sanity)
+# ---------------------------------------------------------------------------
+class TestSyncRateLimiter:
+    def test_basic_acquire(self):
+        limiter = RateLimiter(max_per_second=100.0)
+        limiter.acquire()
+        assert limiter._last_call > 0
+
+    def test_rate_limiting(self):
+        limiter = RateLimiter(max_per_second=10.0)
+        start = time.monotonic()
+        for _ in range(3):
+            limiter.acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.15
+
+
+# ---------------------------------------------------------------------------
+# Pre-configured limiters
+# ---------------------------------------------------------------------------
+class TestPreConfiguredLimiters:
+    def test_sync_limiters_exist(self):
+        from eugene.rate_limit import SEC_LIMITER, FMP_LIMITER, FRED_LIMITER
+        assert SEC_LIMITER.max_per_second == 9.0
+        assert FMP_LIMITER.max_per_second == 5.0
+        assert FRED_LIMITER.max_per_second == 5.0
+
+    def test_async_limiters_exist(self):
+        from eugene.rate_limit import ASYNC_SEC_LIMITER, ASYNC_FMP_LIMITER, ASYNC_FRED_LIMITER
+        assert ASYNC_SEC_LIMITER.max_per_second == 9.0
+        assert ASYNC_FMP_LIMITER.max_per_second == 5.0
+        assert ASYNC_FRED_LIMITER.max_per_second == 5.0
+
+
+# ---------------------------------------------------------------------------
+# asyncio.to_thread wrapping (simulates what eugene_server.py does)
+# ---------------------------------------------------------------------------
+class TestToThreadWrapping:
+    @pytest.mark.asyncio
+    async def test_sync_function_in_thread(self):
+        """Sync function runs in thread pool without blocking event loop."""
+        def slow_sync():
+            time.sleep(0.05)
+            return {"status": "ok"}
+
+        result = await asyncio.to_thread(slow_sync)
+        assert result == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_query_wrapping(self):
+        """Verify query() can be wrapped in to_thread."""
+        mock_query = MagicMock(return_value={"data": {"name": "Apple Inc"}})
+
+        result = await asyncio.to_thread(mock_query, "AAPL", "profile")
+        assert result == {"data": {"name": "Apple Inc"}}
+        mock_query.assert_called_once_with("AAPL", "profile")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_queries(self):
+        """Multiple queries run concurrently in threads."""
+        call_order = []
+
+        def mock_query(identifier, extract):
+            call_order.append(identifier)
+            time.sleep(0.05)
+            return {"ticker": identifier}
+
+        results = await asyncio.gather(
+            asyncio.to_thread(mock_query, "AAPL", "profile"),
+            asyncio.to_thread(mock_query, "MSFT", "profile"),
+            asyncio.to_thread(mock_query, "GOOG", "profile"),
+        )
+
+        assert len(results) == 3
+        assert all(r["ticker"] in ("AAPL", "MSFT", "GOOG") for r in results)
+
+    @pytest.mark.asyncio
+    async def test_exception_propagation(self):
+        """Exceptions in sync functions propagate through to_thread."""
+        def failing_sync():
+            raise ValueError("test error")
+
+        with pytest.raises(ValueError, match="test error"):
+            await asyncio.to_thread(failing_sync)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,91 @@
+"""Tests for CLI commands."""
+from unittest.mock import patch
+from click.testing import CliRunner
+from eugene.cli import main
+
+
+runner = CliRunner()
+
+
+class TestCLIVersion:
+    def test_version_flag(self):
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert "0.8.0" in result.output
+
+
+class TestCLICaps:
+    @patch("eugene.router.capabilities")
+    def test_caps_command(self, mock_caps):
+        mock_caps.return_value = {"service": "eugene-intelligence", "version": "0.8.0"}
+
+        result = runner.invoke(main, ["caps"])
+
+        assert result.exit_code == 0
+        assert "eugene-intelligence" in result.output
+
+
+class TestCLIInfo:
+    def test_info_command(self):
+        result = runner.invoke(main, ["info"])
+
+        assert result.exit_code == 0
+        assert "Eugene Intelligence" in result.output
+        assert "API Keys:" in result.output
+
+
+class TestCLISec:
+    @patch("eugene.router.query")
+    def test_sec_command(self, mock_query):
+        mock_query.return_value = {
+            "status": "success",
+            "data": {"name": "Apple Inc"},
+        }
+
+        result = runner.invoke(main, ["sec", "AAPL", "-e", "profile"])
+
+        assert result.exit_code == 0
+        mock_query.assert_called_once()
+
+    @patch("eugene.router.query")
+    def test_sec_with_options(self, mock_query):
+        mock_query.return_value = {"status": "success", "data": {}}
+
+        result = runner.invoke(main, ["sec", "AAPL", "-e", "financials", "-p", "Q", "-l", "5"])
+
+        assert result.exit_code == 0
+        call_args = mock_query.call_args
+        assert call_args[1]["period"] == "Q"
+        assert call_args[1]["limit"] == 5
+
+
+class TestCLIEcon:
+    @patch("eugene.sources.fred.get_category")
+    def test_econ_category(self, mock_cat):
+        mock_cat.return_value = {"data": [{"series_id": "FEDFUNDS", "value": 5.33}]}
+
+        result = runner.invoke(main, ["econ", "-c", "rates"])
+
+        assert result.exit_code == 0
+
+
+class TestCLIPrices:
+    @patch("eugene.sources.fmp.get_price")
+    def test_prices_command(self, mock_price):
+        mock_price.return_value = {"ticker": "AAPL", "price": 175.50}
+
+        result = runner.invoke(main, ["prices", "AAPL"])
+
+        assert result.exit_code == 0
+        assert "175.5" in result.output
+
+
+class TestCLICrypto:
+    @patch("eugene.sources.fmp.get_crypto_quote")
+    def test_crypto_quote(self, mock_quote):
+        mock_quote.return_value = {"symbol": "BTCUSD", "price": 65000.0}
+
+        result = runner.invoke(main, ["crypto", "BTCUSD"])
+
+        assert result.exit_code == 0
+        assert "65000" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,200 @@
+"""Tests for configuration management."""
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from eugene.config import (
+    APIConfig, SECConfig, CacheConfig, LogConfig,
+    ValidationConfig, ServerConfig, Config, load_config,
+)
+
+
+class TestAPIConfig:
+    def test_defaults(self):
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = APIConfig(fred_api_key=None, fmp_api_key=None, anthropic_api_key=None)
+        assert cfg.fred_api_key is None
+        assert cfg.fmp_api_key is None
+        assert cfg.anthropic_api_key is None
+        assert cfg.anthropic_model == "claude-sonnet-4-20250514"
+
+    def test_env_loading(self):
+        env = {"FRED_API_KEY": "fred123", "FMP_API_KEY": "fmp456", "ANTHROPIC_API_KEY": "ant789"}
+        with patch.dict(os.environ, env, clear=True):
+            cfg = APIConfig()
+        assert cfg.fred_api_key == "fred123"
+        assert cfg.fmp_api_key == "fmp456"
+        assert cfg.anthropic_api_key == "ant789"
+
+    def test_anthropic_model_env(self):
+        with patch.dict(os.environ, {"ANTHROPIC_MODEL": "claude-3-haiku"}, clear=True):
+            cfg = APIConfig()
+        assert cfg.anthropic_model == "claude-3-haiku"
+
+    def test_explicit_values_not_overridden(self):
+        with patch.dict(os.environ, {"FRED_API_KEY": "from_env"}, clear=True):
+            cfg = APIConfig(fred_api_key="explicit")
+        assert cfg.fred_api_key == "explicit"
+
+    def test_is_configured(self):
+        cfg = APIConfig()
+        assert cfg.is_configured is True
+
+
+class TestSECConfig:
+    def test_default_user_agent(self):
+        with patch.dict(os.environ, {"SEC_CONTACT_EMAIL": "test@test.com", "SEC_CONTACT_NAME": "Test"}, clear=True):
+            cfg = SECConfig()
+        assert "test@test.com" in cfg.user_agent
+        assert "Test" in cfg.user_agent
+
+    def test_is_valid_with_email(self):
+        cfg = SECConfig(user_agent="Bot (me@email.com)")
+        assert cfg.is_valid is True
+
+    def test_is_valid_without_email(self):
+        cfg = SECConfig(user_agent="No email here")
+        assert cfg.is_valid is False
+
+    def test_explicit_user_agent(self):
+        cfg = SECConfig(user_agent="Custom Agent (custom@test.com)")
+        assert cfg.user_agent == "Custom Agent (custom@test.com)"
+
+
+class TestCacheConfig:
+    def test_creates_directory(self, tmp_path):
+        cache_dir = tmp_path / "test_cache"
+        cfg = CacheConfig(directory=cache_dir)
+        assert cfg.directory.exists()
+
+    def test_string_to_path(self, tmp_path):
+        cache_dir = str(tmp_path / "str_cache")
+        cfg = CacheConfig(directory=cache_dir)
+        assert isinstance(cfg.directory, Path)
+        assert cfg.directory.exists()
+
+    def test_defaults(self, tmp_path):
+        cfg = CacheConfig(directory=tmp_path)
+        assert cfg.enabled is True
+        assert cfg.filing_ttl_hours == 24 * 7
+        assert cfg.max_size_mb == 1000
+
+
+class TestLogConfig:
+    def test_default_level(self):
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = LogConfig()
+        assert cfg.level == "INFO"
+
+    def test_env_level(self):
+        with patch.dict(os.environ, {"EUGENE_LOG_LEVEL": "debug"}, clear=True):
+            cfg = LogConfig()
+        assert cfg.level == "DEBUG"
+
+
+class TestValidationConfig:
+    def test_defaults(self):
+        cfg = ValidationConfig()
+        assert cfg.min_confidence_threshold == 0.5
+        assert cfg.high_confidence_threshold == 0.85
+
+    def test_invalid_min_threshold(self):
+        with pytest.raises(ValueError, match="min_confidence_threshold"):
+            ValidationConfig(min_confidence_threshold=1.5)
+
+    def test_invalid_high_threshold(self):
+        with pytest.raises(ValueError, match="high_confidence_threshold"):
+            ValidationConfig(high_confidence_threshold=-0.1)
+
+
+class TestServerConfig:
+    def test_default_port(self):
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = ServerConfig()
+        assert cfg.port == 8000
+
+    def test_env_port(self):
+        with patch.dict(os.environ, {"EUGENE_PORT": "9000"}, clear=True):
+            cfg = ServerConfig()
+        assert cfg.port == 9000
+
+
+class TestConfig:
+    def test_creation(self, tmp_path):
+        Config(
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        assert (tmp_path / "data" / "cache").exists()
+        assert (tmp_path / "data" / "extractions").exists()
+
+    def test_is_ready(self, tmp_path):
+        cfg = Config(
+            sec=SECConfig(user_agent="Bot (me@email.com)"),
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        assert cfg.is_ready is True
+
+    def test_is_not_ready(self, tmp_path):
+        cfg = Config(
+            sec=SECConfig(user_agent="No email"),
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        assert cfg.is_ready is False
+
+    def test_validate_issues(self, tmp_path):
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = Config(
+                sec=SECConfig(user_agent="No email"),
+                api=APIConfig(fred_api_key=None, fmp_api_key=None, anthropic_api_key=None),
+                cache=CacheConfig(directory=tmp_path / "cache"),
+                data_dir=tmp_path / "data",
+            )
+        issues = cfg.validate()
+        assert any("SEC user agent" in i for i in issues)
+        assert any("FRED" in i for i in issues)
+        assert any("FMP" in i for i in issues)
+
+    def test_validate_no_issues(self, tmp_path):
+        cfg = Config(
+            sec=SECConfig(user_agent="Bot (me@email.com)"),
+            api=APIConfig(fred_api_key="key1", fmp_api_key="key2"),
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        issues = cfg.validate()
+        assert len(issues) == 0
+
+    def test_summary(self, tmp_path):
+        cfg = Config(
+            sec=SECConfig(user_agent="Bot (me@email.com)"),
+            api=APIConfig(fred_api_key="key1", fmp_api_key="key2"),
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        summary = cfg.summary()
+        assert "FRED API Key" in summary
+        assert "Set" in summary
+        assert "Bot (me@email.com)" in summary
+
+    def test_string_paths(self, tmp_path):
+        cfg = Config(
+            project_root=str(tmp_path),
+            data_dir=str(tmp_path / "data"),
+            cache=CacheConfig(directory=tmp_path / "cache"),
+        )
+        assert isinstance(cfg.project_root, Path)
+        assert isinstance(cfg.data_dir, Path)
+
+
+class TestLoadConfig:
+    def test_returns_config(self, tmp_path):
+        cfg = load_config(
+            cache=CacheConfig(directory=tmp_path / "cache"),
+            data_dir=tmp_path / "data",
+        )
+        assert isinstance(cfg, Config)

--- a/tests/test_disk_cache.py
+++ b/tests/test_disk_cache.py
@@ -1,0 +1,219 @@
+"""Tests for DiskCache (L2 persistent cache) and L1+L2 integration."""
+import time
+
+import pytest
+
+from eugene.cache import DiskCache, cached, cache_clear, _CACHE, get_disk_cache
+
+
+@pytest.fixture
+def disk_cache(tmp_path):
+    """Return a DiskCache backed by a temp directory."""
+    return DiskCache(cache_dir=str(tmp_path / "cache"), max_entries=50)
+
+
+# ---------------------------------------------------------------------------
+# DiskCache unit tests
+# ---------------------------------------------------------------------------
+class TestDiskCacheBasic:
+    def test_set_and_get(self, disk_cache):
+        disk_cache.set("key1", {"name": "Apple"}, ttl=3600)
+        result = disk_cache.get("key1")
+        assert result == {"name": "Apple"}
+
+    def test_get_missing_key(self, disk_cache):
+        assert disk_cache.get("nonexistent") is None
+
+    def test_overwrite(self, disk_cache):
+        disk_cache.set("key1", "old", ttl=3600)
+        disk_cache.set("key1", "new", ttl=3600)
+        assert disk_cache.get("key1") == "new"
+
+    def test_different_value_types(self, disk_cache):
+        disk_cache.set("str", "hello", ttl=3600)
+        disk_cache.set("int", 42, ttl=3600)
+        disk_cache.set("list", [1, 2, 3], ttl=3600)
+        disk_cache.set("nested", {"a": {"b": [1]}}, ttl=3600)
+
+        assert disk_cache.get("str") == "hello"
+        assert disk_cache.get("int") == 42
+        assert disk_cache.get("list") == [1, 2, 3]
+        assert disk_cache.get("nested") == {"a": {"b": [1]}}
+
+
+class TestDiskCacheTTL:
+    def test_expired_entry_returns_none(self, disk_cache):
+        disk_cache.set("expiring", "data", ttl=0)
+        time.sleep(0.01)
+        assert disk_cache.get("expiring") is None
+
+    def test_valid_entry_returns_value(self, disk_cache):
+        disk_cache.set("valid", "data", ttl=3600)
+        assert disk_cache.get("valid") == "data"
+
+    def test_evict_expired(self, disk_cache):
+        disk_cache.set("exp1", "a", ttl=0)
+        disk_cache.set("exp2", "b", ttl=0)
+        disk_cache.set("keep", "c", ttl=3600)
+        time.sleep(0.01)
+
+        removed = disk_cache.evict_expired()
+        assert removed == 2
+        assert disk_cache.get("keep") == "c"
+        assert disk_cache.size() == 1
+
+
+class TestDiskCacheEviction:
+    def test_size_eviction(self, tmp_path):
+        dc = DiskCache(cache_dir=str(tmp_path / "cache"), max_entries=10)
+        for i in range(15):
+            dc.set(f"key{i}", f"val{i}", ttl=3600)
+
+        # After eviction, should be under max_entries
+        assert dc.size() <= 10
+
+    def test_size_returns_count(self, disk_cache):
+        assert disk_cache.size() == 0
+        disk_cache.set("a", 1, ttl=3600)
+        disk_cache.set("b", 2, ttl=3600)
+        assert disk_cache.size() == 2
+
+
+class TestDiskCacheOperations:
+    def test_delete(self, disk_cache):
+        disk_cache.set("to_delete", "data", ttl=3600)
+        assert disk_cache.get("to_delete") == "data"
+        disk_cache.delete("to_delete")
+        assert disk_cache.get("to_delete") is None
+
+    def test_delete_nonexistent(self, disk_cache):
+        # Should not raise
+        disk_cache.delete("nonexistent")
+
+    def test_clear(self, disk_cache):
+        disk_cache.set("a", 1, ttl=3600)
+        disk_cache.set("b", 2, ttl=3600)
+        disk_cache.clear()
+        assert disk_cache.size() == 0
+        assert disk_cache.get("a") is None
+
+    def test_corrupted_file_handled(self, disk_cache):
+        disk_cache.set("key", "value", ttl=3600)
+        # Corrupt the file
+        hashed = disk_cache._hash_key("key")
+        path = disk_cache._path(hashed)
+        path.write_text("NOT JSON")
+        assert disk_cache.get("key") is None
+        # Corrupted file should be cleaned up
+        assert not path.exists()
+
+
+# ---------------------------------------------------------------------------
+# L1 + L2 integration via @cached decorator
+# ---------------------------------------------------------------------------
+class TestCachedDecoratorWithDisk:
+    def setup_method(self):
+        cache_clear()
+
+    def test_l1_miss_l2_hit_promotes(self, tmp_path):
+        """On L1 miss, check L2; on hit, promote to L1."""
+        import eugene.cache as cache_mod
+
+        dc = DiskCache(cache_dir=str(tmp_path / "cache"))
+        old_dc = cache_mod._disk_cache
+        cache_mod._disk_cache = dc
+
+        try:
+            call_count = 0
+
+            @cached(ttl=60, disk=True, disk_ttl=3600)
+            def expensive_fn():
+                nonlocal call_count
+                call_count += 1
+                return {"result": "fresh"}
+
+            # First call: computes and stores in L1 + L2
+            result = expensive_fn()
+            assert result == {"result": "fresh"}
+            assert call_count == 1
+            assert dc.size() == 1
+
+            # Clear L1 only
+            _CACHE.clear()
+
+            # Second call: L1 miss, but L2 hit → promote
+            result = expensive_fn()
+            assert result == {"result": "fresh"}
+            assert call_count == 1  # No recompute — served from L2
+        finally:
+            cache_mod._disk_cache = old_dc
+
+    def test_l1_hit_skips_l2(self, tmp_path):
+        """L1 hit returns immediately without touching disk."""
+        import eugene.cache as cache_mod
+
+        dc = DiskCache(cache_dir=str(tmp_path / "cache"))
+        old_dc = cache_mod._disk_cache
+        cache_mod._disk_cache = dc
+
+        try:
+            call_count = 0
+
+            @cached(ttl=60, disk=True, disk_ttl=3600)
+            def simple_fn():
+                nonlocal call_count
+                call_count += 1
+                return "computed"
+
+            result1 = simple_fn()
+            assert result1 == "computed"
+            assert call_count == 1
+
+            result2 = simple_fn()
+            assert result2 == "computed"
+            assert call_count == 1  # L1 hit, no recompute
+        finally:
+            cache_mod._disk_cache = old_dc
+
+    def test_l1_only_decorator(self):
+        """Default decorator (disk=False) only uses L1."""
+        call_count = 0
+
+        @cached(ttl=60)
+        def l1_only():
+            nonlocal call_count
+            call_count += 1
+            return "value"
+
+        l1_only()
+        l1_only()
+        assert call_count == 1
+
+        _CACHE.clear()
+        l1_only()
+        assert call_count == 2  # No L2 to fall back on
+
+
+# ---------------------------------------------------------------------------
+# get_disk_cache singleton
+# ---------------------------------------------------------------------------
+class TestGetDiskCache:
+    def test_returns_disk_cache_instance(self):
+        import eugene.cache as cache_mod
+        old = cache_mod._disk_cache
+        cache_mod._disk_cache = None
+        try:
+            dc = get_disk_cache()
+            assert isinstance(dc, DiskCache)
+            assert dc.cache_dir.exists()
+
+            # Same instance on second call
+            dc2 = get_disk_cache()
+            assert dc is dc2
+        finally:
+            cache_mod._disk_cache = old
+
+    def test_cache_dir_created(self, tmp_path):
+        cache_dir = tmp_path / "new_cache"
+        DiskCache(cache_dir=str(cache_dir))
+        assert cache_dir.exists()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,84 @@
+"""Tests for error taxonomy — verify each subclass has correct code and status."""
+from eugene.errors import (
+    EugeneError,
+    NotFoundError,
+    SourceError,
+    ValidationError,
+    RateLimitError,
+)
+
+
+class TestEugeneError:
+    def test_base_error(self):
+        e = EugeneError("something broke")
+        assert e.message == "something broke"
+        assert e.code == "INTERNAL_ERROR"
+        assert e.status == 500
+        assert str(e) == "something broke"
+
+    def test_base_error_custom(self):
+        e = EugeneError("custom", code="CUSTOM", status=418)
+        assert e.code == "CUSTOM"
+        assert e.status == 418
+
+
+class TestNotFoundError:
+    def test_not_found(self):
+        e = NotFoundError("Unknown ticker: ZZZZZ")
+        assert e.code == "NOT_FOUND"
+        assert e.status == 404
+        assert "ZZZZZ" in e.message
+        assert isinstance(e, EugeneError)
+
+
+class TestSourceError:
+    def test_source_error(self):
+        e = SourceError("SEC EDGAR", "HTTP 503")
+        assert e.code == "SOURCE_ERROR"
+        assert e.status == 502
+        assert "SEC EDGAR" in e.message
+        assert "HTTP 503" in e.message
+        assert isinstance(e, EugeneError)
+
+
+class TestValidationError:
+    def test_validation_error(self):
+        e = ValidationError("concept parameter required")
+        assert e.code == "VALIDATION_ERROR"
+        assert e.status == 422
+        assert "concept" in e.message
+        assert isinstance(e, EugeneError)
+
+
+class TestRateLimitError:
+    def test_rate_limit_error(self):
+        e = RateLimitError("FMP", retry_after=30)
+        assert e.code == "RATE_LIMITED"
+        assert e.status == 429
+        assert e.retry_after == 30
+        assert "FMP" in e.message
+        assert isinstance(e, EugeneError)
+
+    def test_rate_limit_default_retry(self):
+        e = RateLimitError("SEC")
+        assert e.retry_after == 60
+
+
+class TestErrorHierarchy:
+    def test_all_subclass_eugene_error(self):
+        errors = [NotFoundError("x"), SourceError("s", "m"), ValidationError("v"), RateLimitError("r")]
+        for e in errors:
+            assert isinstance(e, EugeneError)
+            assert isinstance(e, Exception)
+
+    def test_catchable_as_eugene_error(self):
+        try:
+            raise NotFoundError("test")
+        except EugeneError as e:
+            assert e.code == "NOT_FOUND"
+
+    def test_catchable_as_exception(self):
+        try:
+            raise SourceError("SEC", "down")
+        except Exception as e:
+            assert "SEC" in str(e)

--- a/tests/test_fmp.py
+++ b/tests/test_fmp.py
@@ -1,0 +1,276 @@
+"""Tests for FMP source functions — mock HTTP calls, test parsing logic."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from eugene.cache import cache_clear
+from eugene.errors import SourceError
+
+
+# Clear cache before each test class to avoid stale cached values
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache_clear()
+    yield
+    cache_clear()
+
+
+class TestSafeGet:
+    @patch("eugene.sources.fmp.FMP_LIMITER")
+    @patch("eugene.sources.fmp.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.fmp import _safe_get
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"data": "ok"})
+
+        result = _safe_get("http://test.com")
+        assert result == {"data": "ok"}
+
+    @patch("eugene.sources.fmp.FMP_LIMITER")
+    @patch("eugene.sources.fmp.requests.get")
+    def test_402_paid_plan(self, mock_get, mock_limiter):
+        from eugene.sources.fmp import _safe_get
+        resp = MagicMock(status_code=402)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        result = _safe_get("http://test.com")
+        assert result["error"] == "This feature requires a paid FMP plan"
+
+    @patch("eugene.sources.fmp.FMP_LIMITER")
+    @patch("eugene.sources.fmp.requests.get")
+    def test_404_not_found(self, mock_get, mock_limiter):
+        from eugene.sources.fmp import _safe_get
+        resp = MagicMock(status_code=404)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        result = _safe_get("http://test.com")
+        assert result["error"] == "Endpoint not found"
+
+    @patch("eugene.sources.fmp.FMP_LIMITER")
+    @patch("eugene.sources.fmp.requests.get")
+    def test_500_raises_source_error(self, mock_get, mock_limiter):
+        from eugene.sources.fmp import _safe_get
+        resp = MagicMock(status_code=500)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        with pytest.raises(SourceError):
+            _safe_get("http://test.com")
+
+    @patch("eugene.sources.fmp.FMP_LIMITER")
+    @patch("eugene.sources.fmp.requests.get")
+    def test_connection_error(self, mock_get, mock_limiter):
+        from eugene.sources.fmp import _safe_get
+        mock_get.side_effect = requests.exceptions.ConnectionError("timeout")
+
+        with pytest.raises(SourceError, match="timeout"):
+            _safe_get("http://test.com")
+
+
+class TestGetPrice:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_price_success(self, mock_get):
+        from eugene.sources.fmp import get_price
+        mock_get.return_value = [{"price": 175.5, "change": 1.2, "changePercentage": 0.69,
+                                   "volume": 50000000, "marketCap": 2700000000000}]
+
+        result = get_price("AAPL")
+        assert result["ticker"] == "AAPL"
+        assert result["price"] == 175.5
+        assert result["change"] == 1.2
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_price_error(self, mock_get):
+        from eugene.sources.fmp import get_price
+        mock_get.return_value = {"error": "No key"}
+
+        result = get_price("AAPL")
+        assert "error" in result
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_price_empty(self, mock_get):
+        from eugene.sources.fmp import get_price
+        mock_get.return_value = []
+
+        result = get_price("AAPL")
+        assert "error" in result
+
+
+class TestGetProfile:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_profile_success(self, mock_get):
+        from eugene.sources.fmp import get_profile
+        mock_get.return_value = [{"companyName": "Apple Inc", "sector": "Technology",
+                                   "industry": "Consumer Electronics", "ceo": "Tim Cook",
+                                   "fullTimeEmployees": 164000, "country": "US"}]
+
+        result = get_profile("AAPL")
+        assert result["name"] == "Apple Inc"
+        assert result["sector"] == "Technology"
+        assert result["ceo"] == "Tim Cook"
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_profile_no_data(self, mock_get):
+        from eugene.sources.fmp import get_profile
+        mock_get.return_value = []
+
+        result = get_profile("ZZZZZ")
+        assert "error" in result
+
+
+class TestGetEarnings:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_earnings_success(self, mock_get):
+        from eugene.sources.fmp import get_earnings
+        mock_get.return_value = [
+            {"date": "2024-01-25", "eps": 2.18, "epsEstimated": 2.10, "revenue": 119580000000},
+            {"date": "2023-10-26", "eps": 1.46, "epsEstimated": 1.39, "revenue": 89498000000},
+        ]
+
+        result = get_earnings("AAPL")
+        assert result["ticker"] == "AAPL"
+        assert len(result["earnings"]) == 2
+        assert result["earnings"][0]["eps_actual"] == 2.18
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_earnings_error(self, mock_get):
+        from eugene.sources.fmp import get_earnings
+        mock_get.return_value = {"error": "No key"}
+
+        result = get_earnings("AAPL")
+        assert result["earnings"] == []
+
+
+class TestGetEstimates:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_estimates_success(self, mock_get):
+        from eugene.sources.fmp import get_estimates
+        mock_get.return_value = [
+            {"analystName": "John", "analystCompany": "GS", "adjPriceTarget": 200, "publishedDate": "2024-01-15"},
+        ]
+
+        result = get_estimates("AAPL")
+        assert len(result["price_targets"]) == 1
+        assert result["price_targets"][0]["target"] == 200
+
+
+class TestGetNews:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_news_success(self, mock_get):
+        from eugene.sources.fmp import get_news
+        mock_get.return_value = [
+            {"title": "Apple beats", "publishedDate": "2024-01-25", "site": "Reuters", "url": "http://...", "text": "Short text"},
+        ]
+
+        result = get_news("AAPL")
+        assert len(result["articles"]) == 1
+        assert result["articles"][0]["title"] == "Apple beats"
+
+
+class TestGetHistoricalBars:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_daily_bars(self, mock_get):
+        from eugene.sources.fmp import get_historical_bars
+        mock_get.return_value = [
+            {"date": "2024-01-05", "open": 185, "high": 186, "low": 184, "close": 185.5, "volume": 40000000},
+        ]
+
+        result = get_historical_bars("AAPL", "daily")
+        assert result["interval"] == "daily"
+        assert result["count"] == 1
+        assert result["bars"][0]["close"] == 185.5
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_intraday_bars(self, mock_get):
+        from eugene.sources.fmp import get_historical_bars
+        mock_get.return_value = [
+            {"date": "2024-01-05 09:30:00", "open": 185, "high": 186, "low": 184, "close": 185.5, "volume": 1000000},
+        ]
+
+        result = get_historical_bars("AAPL", "5min", from_date="2024-01-01", to_date="2024-01-05")
+        assert result["interval"] == "5min"
+        assert result["count"] == 1
+
+
+class TestGetScreener:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_screener_success(self, mock_get):
+        from eugene.sources.fmp import get_screener
+        mock_get.return_value = [
+            {"symbol": "AAPL", "companyName": "Apple", "marketCap": 2700000000000,
+             "price": 175, "sector": "Technology"},
+            {"symbol": "MSFT", "companyName": "Microsoft", "marketCap": 2500000000000,
+             "price": 380, "sector": "Technology"},
+        ]
+
+        result = get_screener(sector="Technology", limit=10)
+        assert result["count"] == 2
+        assert result["results"][0]["ticker"] == "AAPL"
+        assert result["source"] == "FMP"
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_screener_with_filters(self, mock_get):
+        from eugene.sources.fmp import get_screener
+        mock_get.return_value = []
+
+        result = get_screener(
+            market_cap_min=1000000000, price_min=10, price_max=500,
+            volume_min=1000000, beta_min=0.5, beta_max=2.0,
+            country="US",
+        )
+        assert result["count"] == 0
+
+
+class TestGetCryptoQuote:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_crypto_success(self, mock_get):
+        from eugene.sources.fmp import get_crypto_quote
+        mock_get.return_value = [{"price": 65000, "change": 1500, "changePercentage": 2.3}]
+
+        result = get_crypto_quote("BTCUSD")
+        assert result["symbol"] == "BTCUSD"
+        assert result["price"] == 65000
+
+    @patch("eugene.sources.fmp._safe_get")
+    def test_crypto_no_data(self, mock_get):
+        from eugene.sources.fmp import get_crypto_quote
+        mock_get.return_value = []
+
+        result = get_crypto_quote("FAKECOIN")
+        assert "error" in result
+
+
+class TestGetSharesFloat:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_float_success(self, mock_get):
+        from eugene.sources.fmp import get_shares_float
+        mock_get.return_value = [{"floatShares": 15000000000, "outstandingShares": 15500000000,
+                                   "freeFloat": 96.7, "date": "2024-01-01"}]
+
+        result = get_shares_float("AAPL")
+        assert result["float_shares"] == 15000000000
+        assert result["source"] == "FMP"
+
+
+class TestGetDividends:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_dividends_success(self, mock_get):
+        from eugene.sources.fmp import get_dividends
+        mock_get.return_value = [{"date": "2024-01-15", "dividend": 0.24}]
+
+        result = get_dividends("AAPL")
+        assert result["count"] == 1
+        assert result["dividends"][0]["dividend"] == 0.24
+
+
+class TestGetSplits:
+    @patch("eugene.sources.fmp._safe_get")
+    def test_splits_success(self, mock_get):
+        from eugene.sources.fmp import get_splits
+        mock_get.return_value = [{"date": "2020-08-31", "numerator": 4, "denominator": 1}]
+
+        result = get_splits("AAPL")
+        assert result["count"] == 1
+        assert result["splits"][0]["numerator"] == 4

--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -1,0 +1,115 @@
+"""Tests for FRED economic data source."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+import pandas as pd
+
+from eugene.cache import cache_clear
+from eugene.sources.fred import get_category, get_series, get_all, FRED_SERIES
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache_clear()
+    yield
+    cache_clear()
+
+
+def _mock_series(values, dates=None):
+    """Create a mock pandas Series matching fredapi output."""
+    if dates is None:
+        dates = pd.date_range("2024-01-01", periods=len(values), freq="MS")
+    return pd.Series(values, index=dates)
+
+
+class TestFredSeries:
+    def test_series_categories_defined(self):
+        assert "inflation" in FRED_SERIES
+        assert "employment" in FRED_SERIES
+        assert "rates" in FRED_SERIES
+        assert "gdp" in FRED_SERIES
+        assert len(FRED_SERIES) == 9
+
+
+class TestGetCategory:
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_category_success(self, mock_limiter, mock_get_fred):
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = _mock_series([5.33, 5.50])
+        mock_get_fred.return_value = mock_fred
+
+        result = get_category("rates")
+
+        assert result["category"] == "rates"
+        assert result["source"] == "FRED"
+        assert "FEDFUNDS" in result["series"]
+        assert result["series"]["FEDFUNDS"]["value"] == 5.5
+
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_category_unknown(self, mock_limiter, mock_get_fred):
+        result = get_category("unknown_category")
+        assert "error" in result
+        assert "valid" in result
+
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_category_fetch_error(self, mock_limiter, mock_get_fred):
+        mock_fred = MagicMock()
+        mock_fred.get_series.side_effect = Exception("API error")
+        mock_get_fred.return_value = mock_fred
+
+        result = get_category("rates")
+        # Should still return a result with error entries
+        assert result["category"] == "rates"
+        for series_data in result["series"].values():
+            assert "error" in series_data
+
+
+class TestGetSeries:
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_series_success(self, mock_limiter, mock_get_fred):
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = _mock_series([3.5, 3.6, 3.7])
+        mock_get_fred.return_value = mock_fred
+
+        result = get_series("FEDFUNDS")
+
+        assert result["series_id"] == "FEDFUNDS"
+        assert result["source"] == "FRED"
+        assert len(result["data"]) == 3
+        assert result["data"][-1]["value"] == 3.7
+
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_series_error(self, mock_limiter, mock_get_fred):
+        mock_fred = MagicMock()
+        mock_fred.get_series.side_effect = Exception("Bad series")
+        mock_get_fred.return_value = mock_fred
+
+        result = get_series("INVALID")
+        assert "error" in result
+
+    @patch("eugene.sources.fred._get_fred")
+    @patch("eugene.sources.fred.FRED_LIMITER")
+    def test_series_empty(self, mock_limiter, mock_get_fred):
+        mock_fred = MagicMock()
+        mock_fred.get_series.return_value = pd.Series([], dtype=float)
+        mock_get_fred.return_value = mock_fred
+
+        result = get_series("EMPTY")
+        assert "error" in result
+
+
+class TestGetAll:
+    @patch("eugene.sources.fred.get_category")
+    def test_get_all(self, mock_cat):
+        mock_cat.return_value = {"category": "test", "series": {}, "source": "FRED"}
+
+        result = get_all()
+
+        assert "categories" in result
+        assert result["source"] == "FRED"
+        assert len(result["categories"]) == len(FRED_SERIES)

--- a/tests/test_handlers_fmp.py
+++ b/tests/test_handlers_fmp.py
@@ -1,0 +1,162 @@
+"""Tests for FMP-backed handlers: ohlcv, float, corporate_actions."""
+from unittest.mock import patch
+
+
+# ===== OHLCV Handler =====
+
+class TestOhlcvHandler:
+    @patch("eugene.handlers.ohlcv.get_historical_bars")
+    def test_ohlcv_daily(self, mock_bars):
+        from eugene.handlers.ohlcv import ohlcv_handler
+        mock_bars.return_value = {
+            "ticker": "AAPL", "interval": "daily",
+            "bars": [
+                {"date": "2024-01-05", "open": 185, "high": 186, "low": 184, "close": 185.5, "volume": 40000000},
+                {"date": "2024-01-04", "open": 184, "high": 185, "low": 183, "close": 184.5, "volume": 42000000},
+            ],
+            "count": 2,
+        }
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        result = ohlcv_handler(resolved, {})
+
+        assert result["ticker"] == "AAPL"
+        assert result["interval"] == "daily"
+        assert result["count"] == 2
+        mock_bars.assert_called_once_with("AAPL", interval="daily", from_date=None, to_date=None)
+
+    @patch("eugene.handlers.ohlcv.get_historical_bars")
+    def test_ohlcv_custom_interval(self, mock_bars):
+        from eugene.handlers.ohlcv import ohlcv_handler
+        mock_bars.return_value = {"ticker": "TSLA", "interval": "1hour", "bars": [], "count": 0}
+        resolved = {"ticker": "TSLA", "cik": "0001318605"}
+
+        ohlcv_handler(resolved, {"interval": "1hour"})
+
+        mock_bars.assert_called_once_with("TSLA", interval="1hour", from_date=None, to_date=None)
+
+    @patch("eugene.handlers.ohlcv.get_historical_bars")
+    def test_ohlcv_date_range(self, mock_bars):
+        from eugene.handlers.ohlcv import ohlcv_handler
+        mock_bars.return_value = {"ticker": "AAPL", "interval": "daily", "bars": [], "count": 0}
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        ohlcv_handler(resolved, {"from": "2024-01-01", "to": "2024-06-30"})
+
+        mock_bars.assert_called_once_with("AAPL", interval="daily", from_date="2024-01-01", to_date="2024-06-30")
+
+    def test_ohlcv_no_ticker(self):
+        from eugene.handlers.ohlcv import ohlcv_handler
+        resolved = {"cik": "0000320193"}
+
+        result = ohlcv_handler(resolved, {})
+
+        assert "error" in result
+
+
+# ===== Float Handler =====
+
+class TestFloatHandler:
+    @patch("eugene.handlers.float_data.get_shares_float")
+    def test_float_returns_data(self, mock_float):
+        from eugene.handlers.float_data import float_handler
+        mock_float.return_value = {
+            "ticker": "AAPL", "float_shares": 15000000000,
+            "outstanding_shares": 15200000000, "free_float": 98.7,
+            "date": "2024-01-15", "source": "FMP",
+        }
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        result = float_handler(resolved, {})
+
+        assert result["float_shares"] == 15000000000
+        assert result["outstanding_shares"] == 15200000000
+        assert "short_interest" in result
+        assert result["short_interest"]["status"] == "coming_soon"
+
+    def test_float_no_ticker(self):
+        from eugene.handlers.float_data import float_handler
+        resolved = {"cik": "0000320193"}
+
+        result = float_handler(resolved, {})
+
+        assert "error" in result
+
+
+# ===== Corporate Actions Handler =====
+
+class TestCorporateActionsHandler:
+    @patch("eugene.handlers.corporate_actions.events_handler")
+    @patch("eugene.handlers.corporate_actions.get_splits")
+    @patch("eugene.handlers.corporate_actions.get_dividends")
+    def test_corporate_actions_merges_sources(self, mock_divs, mock_splits, mock_events):
+        from eugene.handlers.corporate_actions import corporate_actions_handler
+        mock_divs.return_value = {
+            "dividends": [
+                {"date": "2024-08-15", "dividend": 0.25, "record_date": "2024-08-12"},
+                {"date": "2024-05-15", "dividend": 0.25, "record_date": "2024-05-12"},
+            ]
+        }
+        mock_splits.return_value = {
+            "splits": [
+                {"date": "2020-08-31", "numerator": 4, "denominator": 1},
+            ]
+        }
+        mock_events.return_value = {
+            "events": [
+                {"form": "8-K", "filed_date": "2024-07-15", "accession": "0000320193-24-000090"},
+            ],
+            "count": 1,
+        }
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        result = corporate_actions_handler(resolved, {})
+
+        assert result["ticker"] == "AAPL"
+        assert result["count"] == 4  # 2 dividends + 1 split + 1 event
+        types = {a["type"] for a in result["actions"]}
+        assert types == {"dividend", "split", "8k_event"}
+
+    @patch("eugene.handlers.corporate_actions.events_handler")
+    @patch("eugene.handlers.corporate_actions.get_splits")
+    @patch("eugene.handlers.corporate_actions.get_dividends")
+    def test_corporate_actions_sorted_by_date(self, mock_divs, mock_splits, mock_events):
+        from eugene.handlers.corporate_actions import corporate_actions_handler
+        mock_divs.return_value = {"dividends": [{"date": "2024-01-01", "dividend": 0.25}]}
+        mock_splits.return_value = {"splits": []}
+        mock_events.return_value = {"events": [{"form": "8-K", "filed_date": "2024-06-01"}], "count": 1}
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        result = corporate_actions_handler(resolved, {})
+
+        dates = [a["date"] for a in result["actions"]]
+        assert dates == sorted(dates, reverse=True)
+
+    @patch("eugene.handlers.corporate_actions.events_handler")
+    @patch("eugene.handlers.corporate_actions.get_splits")
+    @patch("eugene.handlers.corporate_actions.get_dividends")
+    def test_corporate_actions_handles_fmp_failure(self, mock_divs, mock_splits, mock_events):
+        from eugene.handlers.corporate_actions import corporate_actions_handler
+        mock_divs.side_effect = Exception("FMP down")
+        mock_splits.side_effect = Exception("FMP down")
+        mock_events.return_value = {"events": [], "count": 0}
+        resolved = {"ticker": "AAPL", "cik": "0000320193"}
+
+        result = corporate_actions_handler(resolved, {})
+
+        assert "warnings" in result
+        assert len(result["warnings"]) == 2
+
+    @patch("eugene.handlers.corporate_actions.events_handler")
+    @patch("eugene.handlers.corporate_actions.get_splits")
+    @patch("eugene.handlers.corporate_actions.get_dividends")
+    def test_corporate_actions_no_ticker(self, mock_divs, mock_splits, mock_events):
+        from eugene.handlers.corporate_actions import corporate_actions_handler
+        mock_events.return_value = {"events": [], "count": 0}
+        resolved = {"cik": "0000320193"}
+
+        result = corporate_actions_handler(resolved, {})
+
+        assert result["ticker"] is None
+        mock_divs.assert_not_called()
+        mock_splits.assert_not_called()

--- a/tests/test_handlers_misc.py
+++ b/tests/test_handlers_misc.py
@@ -1,0 +1,237 @@
+"""Tests for misc handlers: segments, options, orderbook, export."""
+from unittest.mock import patch
+
+
+# ===== Segments Handler =====
+
+class TestSegmentsHandler:
+    @patch("eugene.handlers.segments.fetch_companyfacts")
+    def test_segments_business(self, mock_fetch):
+        from eugene.handlers.segments import segments_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                        "label": "Revenue",
+                        "units": {
+                            "USD": [
+                                {
+                                    "end": "2024-09-28", "val": 100000000000,
+                                    "form": "10-K", "fy": 2024, "fp": "FY",
+                                    "segments": {
+                                        "us-gaap:StatementBusinessSegmentsAxis": "aapl:iPhoneSegmentMember"
+                                    },
+                                },
+                                {
+                                    "end": "2024-09-28", "val": 50000000000,
+                                    "form": "10-K", "fy": 2024, "fp": "FY",
+                                    "segments": {
+                                        "us-gaap:StatementBusinessSegmentsAxis": "aapl:ServicesSegmentMember"
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = segments_handler(resolved, {})
+
+        assert result["ticker"] == "AAPL"
+        assert result["period_type"] == "FY"
+        assert "2024-09-28" in result["business_segments"]
+        biz = result["business_segments"]["2024-09-28"]
+        assert "iPhoneSegmentMember" in biz
+        assert "ServicesSegmentMember" in biz
+
+    @patch("eugene.handlers.segments.fetch_companyfacts")
+    def test_segments_geographic(self, mock_fetch):
+        from eugene.handlers.segments import segments_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                        "label": "Revenue",
+                        "units": {
+                            "USD": [
+                                {
+                                    "end": "2024-09-28", "val": 80000000000,
+                                    "form": "10-K", "fy": 2024, "fp": "FY",
+                                    "segments": {
+                                        "us-gaap:StatementGeographicalAxis": "aapl:AmericasSegmentMember"
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = segments_handler(resolved, {})
+
+        assert "2024-09-28" in result["geographic_segments"]
+
+    @patch("eugene.handlers.segments.fetch_companyfacts")
+    def test_segments_no_dimensions(self, mock_fetch):
+        from eugene.handlers.segments import segments_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                        "label": "Revenue",
+                        "units": {
+                            "USD": [
+                                {"end": "2024-09-28", "val": 391035000000, "form": "10-K"},
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = segments_handler(resolved, {})
+
+        assert result["business_segments"] == {}
+        assert result["geographic_segments"] == {}
+
+    @patch("eugene.handlers.segments.fetch_companyfacts")
+    def test_segments_quarterly(self, mock_fetch):
+        from eugene.handlers.segments import segments_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                        "label": "Revenue",
+                        "units": {
+                            "USD": [
+                                {
+                                    "end": "2024-06-29", "val": 50000000000,
+                                    "form": "10-Q", "fy": 2024, "fp": "Q3",
+                                    "segments": {
+                                        "us-gaap:StatementBusinessSegmentsAxis": "aapl:iPhoneSegmentMember"
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = segments_handler(resolved, {"period": "Q"})
+
+        assert result["period_type"] == "Q"
+        assert "2024-06-29" in result["business_segments"]
+
+
+# ===== Options Handler (stub) =====
+
+class TestOptionsHandler:
+    def test_options_returns_coming_soon(self):
+        from eugene.handlers.options import options_handler
+
+        result = options_handler({"ticker": "AAPL"}, {})
+
+        assert result["status"] == "coming_soon"
+        assert result["ticker"] == "AAPL"
+
+    def test_options_has_alternatives(self):
+        from eugene.handlers.options import options_handler
+
+        result = options_handler({"ticker": "AAPL"}, {})
+
+        assert "alternatives" in result
+        assert len(result["alternatives"]) > 0
+
+
+# ===== Orderbook Handler (stub) =====
+
+class TestOrderbookHandler:
+    def test_orderbook_returns_coming_soon(self):
+        from eugene.handlers.orderbook import orderbook_handler
+
+        result = orderbook_handler({"ticker": "AAPL"}, {})
+
+        assert result["status"] == "coming_soon"
+        assert result["ticker"] == "AAPL"
+
+
+# ===== Export Handler =====
+
+class TestExportHandler:
+    @patch("eugene.router.query")
+    def test_export_csv_basic(self, mock_query):
+        from eugene.handlers.export import export_financials_csv
+        mock_query.return_value = {
+            "data": {
+                "periods": [
+                    {
+                        "period_end": "2024-09-28", "period_type": "FY",
+                        "fiscal_year": 2024, "filing": "10-K",
+                        "metrics": {
+                            "revenue": {"value": 391035000000},
+                            "net_income": {"value": 93736000000},
+                        }
+                    },
+                    {
+                        "period_end": "2023-09-30", "period_type": "FY",
+                        "fiscal_year": 2023, "filing": "10-K",
+                        "metrics": {
+                            "revenue": {"value": 383285000000},
+                            "net_income": {"value": 96995000000},
+                        }
+                    },
+                ]
+            }
+        }
+
+        csv_str = export_financials_csv("AAPL")
+
+        assert "period_end" in csv_str
+        assert "revenue" in csv_str
+        assert "net_income" in csv_str
+        assert "391035000000" in csv_str
+        lines = csv_str.strip().split("\n")
+        assert len(lines) == 3  # header + 2 rows
+
+    @patch("eugene.router.query")
+    def test_export_csv_empty(self, mock_query):
+        from eugene.handlers.export import export_financials_csv
+        mock_query.return_value = {"data": {"periods": []}}
+
+        csv_str = export_financials_csv("AAPL")
+
+        assert csv_str == ""
+
+    @patch("eugene.router.query")
+    def test_export_csv_none_values_excluded(self, mock_query):
+        from eugene.handlers.export import export_financials_csv
+        mock_query.return_value = {
+            "data": {
+                "periods": [
+                    {
+                        "period_end": "2024-09-28", "period_type": "FY",
+                        "fiscal_year": 2024, "filing": "10-K",
+                        "metrics": {
+                            "revenue": {"value": 100},
+                            "empty_metric": None,
+                        }
+                    },
+                ]
+            }
+        }
+
+        csv_str = export_financials_csv("AAPL")
+
+        assert "revenue" in csv_str
+        assert "empty_metric" not in csv_str

--- a/tests/test_handlers_sec.py
+++ b/tests/test_handlers_sec.py
@@ -1,0 +1,448 @@
+"""Tests for SEC-backed handlers: profile, filings, concepts, ownership, events, sections, exhibits."""
+from unittest.mock import patch
+
+
+# --- Shared fixtures ---
+
+SAMPLE_SUBMISSIONS = {
+    "cik": "0000320193",
+    "name": "Apple Inc",
+    "sic": "3571",
+    "sicDescription": "Electronic Computers",
+    "ein": "942404110",
+    "fiscalYearEnd": "0928",
+    "stateOfIncorporation": "CA",
+    "website": "https://www.apple.com",
+    "addresses": {
+        "business": {
+            "street1": "One Apple Park Way",
+            "city": "Cupertino",
+            "stateOrCountry": "CA",
+            "zipCode": "95014",
+            "phone": "408-996-1010",
+        }
+    },
+    "formerNames": [
+        {"name": "Apple Computer Inc", "to": "2007-01-09"},
+    ],
+    "filings": {
+        "recent": {
+            "form": ["10-K", "10-Q", "8-K", "4", "8-K", "13F-HR", "10-Q"],
+            "filingDate": ["2024-11-01", "2024-08-02", "2024-07-15", "2024-06-01", "2024-05-20", "2024-05-01", "2024-05-01"],
+            "accessionNumber": [
+                "0000320193-24-000123",
+                "0000320193-24-000100",
+                "0000320193-24-000090",
+                "0000320193-24-000080",
+                "0000320193-24-000070",
+                "0000320193-24-000060",
+                "0000320193-24-000050",
+            ],
+            "primaryDocument": [
+                "aapl-20240928.htm",
+                "aapl-20240629.htm",
+                "aapl-8k.htm",
+                "form4.xml",
+                "aapl-8k2.htm",
+                "infotable.xml",
+                "aapl-20240330.htm",
+            ],
+            "primaryDocDescription": [
+                "10-K Annual Report",
+                "10-Q Quarterly Report",
+                "8-K Current Report",
+                "Form 4",
+                "8-K Current Report",
+                "13F-HR",
+                "10-Q Quarterly Report",
+            ],
+        }
+    },
+}
+
+
+# ===== Profile Handler =====
+
+class TestProfileHandler:
+    @patch("eugene.handlers.profile.fetch_submissions")
+    def test_profile_returns_company_info(self, mock_fetch):
+        from eugene.handlers.profile import profile_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = profile_handler(resolved, {})
+
+        assert result["name"] == "Apple Inc"
+        assert result["cik"] == "0000320193"
+        assert result["ticker"] == "AAPL"
+        assert result["sic"] == "3571"
+        assert result["sic_description"] == "Electronic Computers"
+        assert result["ein"] == "942404110"
+        assert result["fiscal_year_end"] == "0928"
+        assert result["state_of_incorporation"] == "CA"
+
+    @patch("eugene.handlers.profile.fetch_submissions")
+    def test_profile_address(self, mock_fetch):
+        from eugene.handlers.profile import profile_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = profile_handler(resolved, {})
+
+        assert result["address"]["city"] == "Cupertino"
+        assert result["address"]["state"] == "CA"
+        assert result["phone"] == "408-996-1010"
+
+    @patch("eugene.handlers.profile.fetch_submissions")
+    def test_profile_former_names(self, mock_fetch):
+        from eugene.handlers.profile import profile_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = profile_handler(resolved, {})
+
+        assert len(result["former_names"]) == 1
+        assert result["former_names"][0]["name"] == "Apple Computer Inc"
+
+    @patch("eugene.handlers.profile.fetch_submissions")
+    def test_profile_filings_count(self, mock_fetch):
+        from eugene.handlers.profile import profile_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193", "ticker": "AAPL"}
+
+        result = profile_handler(resolved, {})
+
+        assert result["filings_count"] == 7
+
+
+# ===== Filings Handler =====
+
+class TestFilingsHandler:
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_default_limit(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {})
+
+        assert "filings" in result
+        assert result["total_available"] == 7
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_form_filter(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {"form": "10-K"})
+
+        assert all(f["form"] == "10-K" for f in result["filings"])
+        assert len(result["filings"]) == 1
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_multi_form_filter(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {"form": "8-K,10-Q"})
+
+        forms = {f["form"] for f in result["filings"]}
+        assert forms <= {"8-K", "10-Q"}
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_limit(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {"limit": 3})
+
+        assert len(result["filings"]) == 3
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_date_filter(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {"from": "2024-06-01", "to": "2024-08-31"})
+
+        for f in result["filings"]:
+            assert f["filed_date"] >= "2024-06-01"
+            assert f["filed_date"] <= "2024-08-31"
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_filings_url_format(self, mock_fetch):
+        from eugene.handlers.filings import filings_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = filings_handler(resolved, {"form": "10-K"})
+
+        filing = result["filings"][0]
+        assert "sec.gov/Archives/edgar/data" in filing["url"]
+        assert filing["accession"] == "0000320193-24-000123"
+
+
+# ===== Concepts Handler =====
+
+class TestConceptsHandler:
+    @patch("eugene.handlers.concepts_raw.fetch_companyfacts")
+    def test_concepts_single_tag(self, mock_fetch):
+        from eugene.handlers.concepts_raw import concepts_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "Revenues": {
+                        "label": "Revenues",
+                        "units": {
+                            "USD": [
+                                {"end": "2024-09-28", "val": 391035000000, "form": "10-K", "fy": 2024, "fp": "FY"},
+                                {"end": "2023-09-30", "val": 383285000000, "form": "10-K", "fy": 2023, "fp": "FY"},
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193"}
+
+        result = concepts_handler(resolved, {"concept": "Revenues"})
+
+        assert "concepts" in result
+        assert "Revenues" in result["concepts"]
+        assert result["concepts"]["Revenues"]["total"] == 2
+        assert result["concepts"]["Revenues"]["values"][0]["value"] == 391035000000
+
+    @patch("eugene.handlers.concepts_raw.fetch_companyfacts")
+    def test_concepts_missing_tag(self, mock_fetch):
+        from eugene.handlers.concepts_raw import concepts_handler
+        mock_fetch.return_value = {"facts": {"us-gaap": {}, "dei": {}}}
+        resolved = {"cik": "0000320193"}
+
+        result = concepts_handler(resolved, {"concept": "Nonexistent"})
+
+        assert "error" in result["concepts"]["Nonexistent"]
+
+    def test_concepts_missing_param_raises_validation_error(self):
+        from eugene.handlers.concepts_raw import concepts_handler
+        from eugene.errors import ValidationError
+
+        try:
+            concepts_handler({"cik": "0000320193"}, {})
+            assert False, "Should raise ValidationError"
+        except ValidationError as e:
+            assert "concept parameter required" in e.message
+
+    @patch("eugene.handlers.concepts_raw.fetch_companyfacts")
+    def test_concepts_form_filter(self, mock_fetch):
+        from eugene.handlers.concepts_raw import concepts_handler
+        mock_fetch.return_value = {
+            "facts": {
+                "us-gaap": {
+                    "Assets": {
+                        "label": "Assets",
+                        "units": {
+                            "USD": [
+                                {"end": "2024-09-28", "val": 100, "form": "10-K"},
+                                {"end": "2024-06-29", "val": 90, "form": "10-Q"},
+                            ]
+                        }
+                    }
+                },
+                "dei": {},
+            }
+        }
+        resolved = {"cik": "0000320193"}
+
+        result = concepts_handler(resolved, {"concept": "Assets", "form": "10-K"})
+
+        values = result["concepts"]["Assets"]["values"]
+        assert all(v["form"] == "10-K" for v in values)
+
+
+# ===== Events Handler =====
+
+class TestEventsHandler:
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_events_filters_8k(self, mock_fetch):
+        from eugene.handlers.events import events_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = events_handler(resolved, {})
+
+        assert "events" in result
+        assert result["count"] >= 0
+        for event in result["events"]:
+            assert event["form"] in ("8-K", "8-K/A")
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_events_with_limit(self, mock_fetch):
+        from eugene.handlers.events import events_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = events_handler(resolved, {"limit": 1})
+
+        assert result["count"] <= 1
+
+
+# ===== Exhibits Handler =====
+
+class TestExhibitsHandler:
+    @patch("eugene.handlers.exhibits.fetch_submissions")
+    def test_exhibits_default_10k(self, mock_fetch):
+        from eugene.handlers.exhibits import exhibits_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = exhibits_handler(resolved, {})
+
+        assert "filings" in result
+        for f in result["filings"]:
+            assert f["form"] == "10-K"
+            assert "index_url" in f
+
+    @patch("eugene.handlers.exhibits.fetch_submissions")
+    def test_exhibits_form_filter(self, mock_fetch):
+        from eugene.handlers.exhibits import exhibits_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = exhibits_handler(resolved, {"form": "10-Q"})
+
+        for f in result["filings"]:
+            assert f["form"] == "10-Q"
+
+    @patch("eugene.handlers.exhibits.fetch_submissions")
+    def test_exhibits_limit(self, mock_fetch):
+        from eugene.handlers.exhibits import exhibits_handler
+        mock_fetch.return_value = SAMPLE_SUBMISSIONS
+        resolved = {"cik": "0000320193"}
+
+        result = exhibits_handler(resolved, {"form": "10-Q", "limit": 1})
+
+        assert len(result["filings"]) == 1
+
+
+# ===== Sections Handler =====
+
+class TestSectionsHandler:
+    @patch("eugene.handlers.sections.fetch_filing_html")
+    @patch("eugene.handlers.sections.fetch_submissions")
+    def test_sections_mdna(self, mock_subs, mock_html):
+        from eugene.handlers.sections import sections_handler
+        mock_subs.return_value = SAMPLE_SUBMISSIONS
+        mock_html.return_value = """
+        <html><body>
+        <h2>Item 7. Management's Discussion and Analysis</h2>
+        <p>We had a great year with record revenue growth across all segments.</p>
+        <h2>Item 8. Financial Statements</h2>
+        </body></html>
+        """
+        resolved = {"cik": "0000320193"}
+
+        result = sections_handler(resolved, {"section": "mdna"})
+
+        assert "sections" in result
+        assert "mdna" in result["sections"]
+        assert result["sections"]["mdna"]["text"] is not None
+        assert "Management" in result["sections"]["mdna"]["text"]
+
+    @patch("eugene.handlers.sections.fetch_filing_html")
+    @patch("eugene.handlers.sections.fetch_submissions")
+    def test_sections_not_found(self, mock_subs, mock_html):
+        from eugene.handlers.sections import sections_handler
+        mock_subs.return_value = SAMPLE_SUBMISSIONS
+        mock_html.return_value = "<html><body>No relevant sections here</body></html>"
+        resolved = {"cik": "0000320193"}
+
+        result = sections_handler(resolved, {"section": "risk_factors"})
+
+        assert result["sections"]["risk_factors"]["text"] is None
+
+    @patch("eugene.handlers.sections.fetch_submissions")
+    def test_sections_no_filing(self, mock_subs):
+        from eugene.handlers.sections import sections_handler
+        empty_subs = {
+            "filings": {"recent": {"form": [], "filingDate": [], "accessionNumber": [], "primaryDocument": []}}
+        }
+        mock_subs.return_value = empty_subs
+        resolved = {"cik": "0000320193"}
+
+        result = sections_handler(resolved, {"section": "mdna"})
+
+        assert "error" in result
+
+
+# ===== Ownership Handler =====
+
+class TestOwnershipHandler:
+    @patch("eugene.handlers.ownership.fetch_filing_xml")
+    @patch("eugene.handlers.ownership.fetch_filing_index")
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_ownership_parses_13f(self, mock_subs, mock_index, mock_xml):
+        from eugene.handlers.ownership import ownership_handler
+        mock_subs.return_value = SAMPLE_SUBMISSIONS
+        mock_index.return_value = {
+            "directory": {
+                "item": [
+                    {"name": "primary_doc.xml"},
+                    {"name": "infotable.xml"},
+                ]
+            }
+        }
+        mock_xml.return_value = """<?xml version="1.0"?>
+        <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+            <infoTable>
+                <nameOfIssuer>APPLE INC</nameOfIssuer>
+                <titleOfClass>COM</titleOfClass>
+                <cusip>037833100</cusip>
+                <value>5000000</value>
+                <shrsOrPrnAmt>
+                    <sshPrnamt>25000</sshPrnamt>
+                    <sshPrnamtType>SH</sshPrnamtType>
+                </shrsOrPrnAmt>
+                <investmentDiscretion>SOLE</investmentDiscretion>
+                <votingAuthority>
+                    <Sole>25000</Sole>
+                    <Shared>0</Shared>
+                    <None>0</None>
+                </votingAuthority>
+            </infoTable>
+        </informationTable>
+        """
+        resolved = {"cik": "0000320193"}
+
+        result = ownership_handler(resolved, {"limit": 1})
+
+        assert "ownership_filings" in result
+        assert result["count"] >= 0
+        if result["count"] > 0:
+            filing = result["ownership_filings"][0]
+            assert filing["position_count"] >= 0
+
+    @patch("eugene.handlers.filings.fetch_submissions")
+    def test_ownership_no_13f_filings(self, mock_subs):
+        from eugene.handlers.ownership import ownership_handler
+        subs_no_13f = {
+            "filings": {
+                "recent": {
+                    "form": ["10-K", "10-Q"],
+                    "filingDate": ["2024-11-01", "2024-08-02"],
+                    "accessionNumber": ["0000320193-24-000123", "0000320193-24-000100"],
+                    "primaryDocument": ["doc1.htm", "doc2.htm"],
+                    "primaryDocDescription": ["10-K", "10-Q"],
+                }
+            }
+        }
+        mock_subs.return_value = subs_no_13f
+        resolved = {"cik": "0000320193"}
+
+        result = ownership_handler(resolved, {})
+
+        assert result["count"] == 0

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,161 @@
+"""Tests for identifier resolver (ticker, CIK, accession → company identity)."""
+from unittest.mock import patch
+
+import pytest
+
+from eugene.resolver import resolve, _load_ticker_map, ACCESSION_RE, CIK_RE
+from eugene.errors import NotFoundError
+from eugene.cache import cache_clear
+
+
+MOCK_TICKERS = {
+    "0": {"ticker": "AAPL", "cik_str": "320193", "title": "Apple Inc"},
+    "1": {"ticker": "MSFT", "cik_str": "789019", "title": "Microsoft Corp"},
+    "2": {"ticker": "GOOG", "cik_str": "1652044", "title": "Alphabet Inc"},
+}
+
+MOCK_SUBMISSIONS = {
+    "name": "Apple Inc",
+    "cik": "0000320193",
+    "sic": "3571",
+    "fiscalYearEnd": "0928",
+    "tickers": ["AAPL"],
+}
+
+
+class TestRegexPatterns:
+    def test_accession_pattern(self):
+        assert ACCESSION_RE.match("0000320193-24-000123")
+        assert ACCESSION_RE.match("1234567890-99-123456")
+        assert not ACCESSION_RE.match("AAPL")
+        assert not ACCESSION_RE.match("320193")
+        assert not ACCESSION_RE.match("123-45-678")
+
+    def test_cik_pattern(self):
+        assert CIK_RE.match("320193")
+        assert CIK_RE.match("0000320193")
+        assert CIK_RE.match("1")
+        assert not CIK_RE.match("AAPL")
+        assert not CIK_RE.match("123-456")
+
+
+class TestLoadTickerMap:
+    def setup_method(self):
+        cache_clear()
+
+    @patch("eugene.resolver.fetch_tickers")
+    def test_builds_ticker_map(self, mock_fetch):
+        mock_fetch.return_value = MOCK_TICKERS
+        result = _load_ticker_map()
+        assert "AAPL" in result
+        assert result["AAPL"]["cik"] == "0000320193"
+        assert result["AAPL"]["company"] == "Apple Inc"
+
+    @patch("eugene.resolver.fetch_tickers")
+    def test_uppercase_tickers(self, mock_fetch):
+        mock_fetch.return_value = {"0": {"ticker": "aapl", "cik_str": "320193", "title": "Apple"}}
+        result = _load_ticker_map()
+        assert "AAPL" in result
+
+
+class TestResolveByTicker:
+    def setup_method(self):
+        cache_clear()
+
+    @patch("eugene.resolver.fetch_submissions")
+    @patch("eugene.resolver.fetch_tickers")
+    def test_resolve_ticker(self, mock_tickers, mock_subs):
+        mock_tickers.return_value = MOCK_TICKERS
+        mock_subs.return_value = MOCK_SUBMISSIONS
+
+        result = resolve("AAPL")
+
+        assert result["ticker"] == "AAPL"
+        assert result["cik"] == "0000320193"
+        assert result["company"] == "Apple Inc"
+        assert result["sic"] == "3571"
+
+    @patch("eugene.resolver.fetch_submissions")
+    @patch("eugene.resolver.fetch_tickers")
+    def test_resolve_lowercase(self, mock_tickers, mock_subs):
+        mock_tickers.return_value = MOCK_TICKERS
+        mock_subs.return_value = MOCK_SUBMISSIONS
+
+        result = resolve("aapl")
+        assert result["ticker"] == "AAPL"
+
+    @patch("eugene.resolver.fetch_tickers")
+    def test_resolve_unknown_ticker(self, mock_tickers):
+        mock_tickers.return_value = MOCK_TICKERS
+
+        with pytest.raises(NotFoundError, match="Unknown ticker: ZZZZZ"):
+            resolve("ZZZZZ")
+
+    @patch("eugene.resolver.fetch_submissions")
+    @patch("eugene.resolver.fetch_tickers")
+    def test_resolve_ticker_submissions_fail(self, mock_tickers, mock_subs):
+        mock_tickers.return_value = MOCK_TICKERS
+        mock_subs.side_effect = Exception("Network error")
+
+        result = resolve("AAPL")
+        # Should still return with ticker and cik from ticker map
+        assert result["ticker"] == "AAPL"
+        assert result["cik"] == "0000320193"
+
+
+class TestResolveByCIK:
+    def setup_method(self):
+        cache_clear()
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_cik(self, mock_subs):
+        mock_subs.return_value = MOCK_SUBMISSIONS
+
+        result = resolve("320193")
+
+        assert result["cik"] == "0000320193"
+        assert result["company"] == "Apple Inc"
+        assert result["ticker"] == "AAPL"
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_padded_cik(self, mock_subs):
+        mock_subs.return_value = MOCK_SUBMISSIONS
+
+        result = resolve("0000320193")
+        assert result["cik"] == "0000320193"
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_cik_failure(self, mock_subs):
+        mock_subs.side_effect = Exception("Not found")
+
+        with pytest.raises(NotFoundError, match="Could not resolve CIK"):
+            resolve("999999999")
+
+
+class TestResolveByAccession:
+    def setup_method(self):
+        cache_clear()
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_accession(self, mock_subs):
+        mock_subs.return_value = MOCK_SUBMISSIONS
+
+        result = resolve("0000320193-24-000123")
+
+        assert result["cik"] == "0000320193"
+        assert result["company"] == "Apple Inc"
+        assert result["accession"] == "0000320193-24-000123"
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_accession_failure(self, mock_subs):
+        mock_subs.side_effect = Exception("Not found")
+
+        with pytest.raises(NotFoundError, match="Could not resolve accession"):
+            resolve("0000320193-24-000123")
+
+    @patch("eugene.resolver.fetch_submissions")
+    def test_resolve_accession_no_tickers(self, mock_subs):
+        mock_subs.return_value = {"name": "Unknown Corp", "tickers": []}
+
+        result = resolve("0000320193-24-000123")
+        assert result["ticker"] is None

--- a/tests/test_sec_api.py
+++ b/tests/test_sec_api.py
@@ -1,0 +1,193 @@
+"""Tests for SEC EDGAR API source functions."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from eugene.cache import cache_clear
+from eugene.errors import SourceError
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache_clear()
+    yield
+    cache_clear()
+
+
+class TestFetchTickers:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_tickers
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"0": {"cik_str": "320193", "ticker": "AAPL", "title": "Apple Inc"}},
+        )
+
+        result = fetch_tickers()
+        assert "0" in result
+        assert result["0"]["ticker"] == "AAPL"
+
+    def test_uses_disk_cache(self):
+        """fetch_tickers is configured with disk caching."""
+        from eugene.sources.sec_api import fetch_tickers
+        # Verify the decorator is applied (function is wrapped)
+        assert hasattr(fetch_tickers, "__wrapped__")
+
+
+class TestFetchSubmissions:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_submissions
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"name": "Apple Inc", "cik": "0000320193", "sic": "3571"},
+        )
+
+        result = fetch_submissions("320193")
+        assert result["name"] == "Apple Inc"
+
+    def test_cik_padding_logic(self):
+        """CIK values get zero-padded to 10 digits."""
+        assert "123".zfill(10) == "0000000123"
+        assert "320193".zfill(10) == "0000320193"
+        assert "0000320193".zfill(10) == "0000320193"
+
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_http_error(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_submissions
+        resp = MagicMock(status_code=404)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        with pytest.raises(SourceError, match="HTTP 404"):
+            fetch_submissions("999999")
+
+
+class TestFetchCompanyFacts:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_companyfacts
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"facts": {"us-gaap": {"Revenue": {"units": {"USD": []}}}}},
+        )
+
+        result = fetch_companyfacts("320193")
+        assert "facts" in result
+
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_http_error(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_companyfacts
+        # Clear both L1 and L2 caches so the function actually makes the HTTP call
+        cache_clear()
+        import eugene.cache as cache_mod
+        old_dc = cache_mod._disk_cache
+        cache_mod._disk_cache = None
+        try:
+            resp = MagicMock(status_code=500)
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+            mock_get.return_value = resp
+
+            with pytest.raises(SourceError, match="companyfacts"):
+                fetch_companyfacts("999")  # Use different CIK to avoid L1 cache from success test
+        finally:
+            cache_mod._disk_cache = old_dc
+
+
+class TestFetchFilingHtml:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_filing_html
+        mock_get.return_value = MagicMock(status_code=200, text="<html>Filing</html>")
+
+        result = fetch_filing_html("320193", "0000320193-24-000123", "doc.htm")
+        assert "Filing" in result
+
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_http_error(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_filing_html
+        resp = MagicMock(status_code=404)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        with pytest.raises(SourceError):
+            fetch_filing_html("320193", "0000320193-24-000123", "doc.htm")
+
+
+class TestFetchFilingIndex:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_filing_index
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"directory": {"item": [{"name": "doc.htm"}]}},
+        )
+
+        result = fetch_filing_index("320193", "0000320193-24-000123")
+        assert "directory" in result
+
+
+class TestFetchFilingXml:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import fetch_filing_xml
+        mock_get.return_value = MagicMock(status_code=200, text="<xml>data</xml>")
+
+        result = fetch_filing_xml("320193", "0000320193-24-000123", "form4.xml")
+        assert "data" in result
+
+
+class TestSearchFulltext:
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_success(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import search_fulltext
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"hits": {"total": 5, "hits": []}},
+        )
+
+        result = search_fulltext("apple revenue", forms=["10-K"])
+        assert "hits" in result
+
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_with_dates(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import search_fulltext
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"hits": {}})
+
+        search_fulltext("revenue", date_from="2024-01-01", date_to="2024-12-31")
+        call_params = mock_get.call_args[1]["params"]
+        assert "startdt" in call_params
+        assert "enddt" in call_params
+
+    @patch("eugene.sources.sec_api.SEC_LIMITER")
+    @patch("eugene.sources.sec_api.requests.get")
+    def test_http_error(self, mock_get, mock_limiter):
+        from eugene.sources.sec_api import search_fulltext
+        resp = MagicMock(status_code=500)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        mock_get.return_value = resp
+
+        with pytest.raises(SourceError, match="fulltext"):
+            search_fulltext("test query")
+
+
+class TestFilerCik:
+    def test_extracts_cik(self):
+        from eugene.sources.sec_api import _filer_cik
+        assert _filer_cik("0000320193-24-000123") == "320193"
+
+    def test_strips_leading_zeros(self):
+        from eugene.sources.sec_api import _filer_cik
+        assert _filer_cik("0000000001-24-000123") == "1"


### PR DESCRIPTION
## Summary
- **287 tests, 70% coverage** — up from 107 tests / 38% coverage
- **Async HTTP** — all REST route sync calls wrapped in `asyncio.to_thread()` so the event loop is never blocked
- **Persistent L2 disk cache** — `DiskCache` class with SHA-256 keys, TTL expiry, and size eviction; enabled for SEC tickers, submissions, and companyfacts

## New Test Files (12)
- `test_handlers_sec.py` — profile, filings, concepts, events, exhibits, sections, ownership handlers
- `test_handlers_fmp.py` — ohlcv, float, corporate_actions handlers  
- `test_handlers_misc.py` — segments, options, orderbook, export handlers
- `test_cli.py` — CLI commands (version, caps, info, sec, econ, prices, crypto)
- `test_errors.py` — error taxonomy (EugeneError, NotFoundError, SourceError, ValidationError, RateLimitError)
- `test_config.py` — all configuration classes and validation
- `test_resolver.py` — ticker/CIK/accession resolution with mocked SEC calls
- `test_fmp.py` — all FMP source functions with mocked HTTP
- `test_fred.py` — all FRED source functions with mocked fredapi
- `test_sec_api.py` — all SEC EDGAR HTTP functions with mocked requests
- `test_async.py` — AsyncRateLimiter and asyncio.to_thread wrapping
- `test_disk_cache.py` — DiskCache CRUD, TTL, eviction, L1+L2 integration

## Key Changes
- `eugene/cache.py` — Added `DiskCache` class and updated `@cached` decorator with `disk`/`disk_ttl` params for L1+L2 layered caching
- `eugene/rate_limit.py` — Added `AsyncRateLimiter` with `asyncio.Lock` and pre-configured async limiters
- `eugene_server.py` — All REST handlers now use `asyncio.to_thread()` for sync data calls; disk cache warmup on startup
- `eugene/sources/sec_api.py` — Enabled disk caching for `fetch_tickers` (7d), `fetch_submissions` (1d), `fetch_companyfacts` (7d)

## Test plan
- [x] `ruff check .` → All checks passed
- [x] `pytest tests/ --cov=eugene` → 287 passed, 70% coverage
- [x] `python -m eugene --version` → 0.8.0
- [x] `python -m eugene info` → 19 extracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)