### PR TITLE
Fix: add missing frontend lib files for Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
+!frontend/src/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,26 @@
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
+export async function fetchSEC<T = any>(ticker: string, params: URLSearchParams): Promise<T> {
+  return eugeneApi<T>(`/v1/sec/${encodeURIComponent(ticker)}?${params.toString()}`);
+}
+
+export async function eugeneApi<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T> {
+  const url = new URL(path, window.location.origin);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') {
+        url.searchParams.set(k, String(v));
+      }
+    });
+  }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = import.meta.env.VITE_API_KEY;
+  if (apiKey) headers['X-API-Key'] = apiKey;
+
+  const res = await fetch(`${API_BASE}${url.pathname}${url.search}`, { headers });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${res.status}: ${body || res.statusText}`);
+  }
+  return res.json();
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,233 @@
+export interface Provenance {
+  source: string;
+  url?: string;
+}
+
+export interface EugeneResponse<T> {
+  status: 'success' | 'partial' | 'error';
+  identifier: string;
+  resolved: {
+    ticker?: string;
+    cik?: string;
+    company?: string;
+  };
+  data: T;
+  provenance: Provenance[];
+  metadata: {
+    service: string;
+    version: string;
+  };
+  error?: string;
+}
+
+// Profile
+export interface ProfileData {
+  name: string;
+  cik: string;
+  sic: string;
+  sic_description: string;
+  ticker: string;
+  exchanges: string[];
+  state: string;
+  fiscal_year_end: string;
+  website?: string;
+  phone?: string;
+  address?: {
+    street1?: string;
+    city?: string;
+    state?: string;
+    zip?: string;
+  };
+}
+
+// Financials
+export interface MetricValue {
+  value: number;
+  unit: string;
+  source_tag: string;
+  derived?: boolean;
+  formula?: string;
+}
+
+export interface FinancialPeriod {
+  period_end: string;
+  period_type: string;
+  fiscal_year: number | null;
+  filing: string;
+  accession: string;
+  filed_date: string;
+  income_statement: Record<string, MetricValue>;
+  balance_sheet: Record<string, MetricValue>;
+  cash_flow_statement: Record<string, MetricValue>;
+}
+
+export interface FinancialsData {
+  periods: FinancialPeriod[];
+  concepts_found: string[];
+  period_type: string;
+}
+
+// Metrics
+export interface MetricsData {
+  periods: {
+    period_end: string;
+    metrics: {
+      profitability?: Record<string, number>;
+      liquidity?: Record<string, number>;
+      leverage?: Record<string, number>;
+      efficiency?: Record<string, number>;
+      valuation?: Record<string, number>;
+      growth?: Record<string, number>;
+      per_share?: Record<string, number>;
+    };
+  }[];
+}
+
+// Prices
+export interface PriceData {
+  ticker: string;
+  price: number;
+  change: number;
+  change_percent: number;
+  volume: number;
+  market_cap: number;
+  day_high: number;
+  day_low: number;
+  year_high: number;
+  year_low: number;
+  avg_50: number;
+  avg_200: number;
+}
+
+// OHLCV
+export interface OHLCVBar {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export interface OHLCVData {
+  ticker: string;
+  interval: string;
+  count: number;
+  bars: OHLCVBar[];
+}
+
+// Screener
+export interface ScreenerResult {
+  symbol: string;
+  companyName: string;
+  marketCap: number;
+  price: number;
+  change: number;
+  changesPercentage: number;
+  sector: string;
+  industry: string;
+  country: string;
+  beta: number;
+  volume: number;
+  lastAnnualDividend: number;
+  exchange: string;
+  exchangeShortName: string;
+  isActivelyTrading: boolean;
+}
+
+// Economics / FRED
+export interface FredSeries {
+  id: string;
+  title: string;
+  value: number | string;
+  date: string;
+  units: string;
+  frequency: string;
+  history?: { date: string; value: number }[];
+}
+
+export interface FredCategory {
+  category: string;
+  series: FredSeries[];
+}
+
+// Filings — matches backend filings_handler response
+export interface Filing {
+  form: string;
+  filed_date: string;
+  accession: string;
+  description: string;
+  url: string;
+}
+
+export interface FilingsData {
+  filings: Filing[];
+  total_available: number;
+}
+
+// Insiders — matches backend insiders_handler response
+export interface InsiderTx {
+  date: string;
+  security: string;
+  transaction_code: string;
+  transaction_type: string;
+  shares: number | null;
+  price_per_share: number | null;
+  direction: string;
+  shares_owned_after: number | null;
+  derivative: boolean;
+}
+
+export interface InsiderFiling {
+  form: string;
+  filed_date: string;
+  accession: string;
+  description: string;
+  url: string;
+  owner: {
+    name: string;
+    cik?: string;
+    is_director: boolean;
+    is_officer: boolean;
+    title: string;
+  };
+  issuer?: {
+    name: string;
+    ticker: string;
+  };
+  transactions: InsiderTx[];
+}
+
+export interface InsidersData {
+  insider_filings: InsiderFiling[];
+  count: number;
+  summary: {
+    total_purchases: number;
+    total_sales: number;
+    net_direction: string;
+  };
+  sentiment: {
+    score: number;
+    signal: string;
+    buy_value: number;
+    sell_value: number;
+    net_value: number;
+  };
+}
+
+// Sections — matches backend sections_handler response
+export interface SectionData {
+  text: string | null;
+  char_count?: number;
+  truncated?: boolean;
+  reason?: string;
+}
+
+export interface SectionsData {
+  filing: {
+    form: string;
+    filed_date: string;
+    accession: string;
+  };
+  sections: Record<string, SectionData>;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,41 @@
+export function formatCurrency(value: number | undefined | null): string {
+  if (value === undefined || value === null) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(2)}`;
+}
+
+export function formatNumber(value: number | undefined | null): string {
+  if (value === undefined || value === null) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(1)}K`;
+  return `${sign}${abs.toLocaleString()}`;
+}
+
+export function formatPercent(value: number | undefined | null): string {
+  if (value === undefined || value === null) return '—';
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+export function formatPrice(value: number | undefined | null): string {
+  if (value === undefined || value === null) return '—';
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+export function metricLabel(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- `frontend/src/lib/` (api.ts, types.ts, utils.ts) was excluded by the root `.gitignore`'s `lib/` rule
- Scoped the ignore to `/lib/` and added exception for `frontend/src/lib/`
- Fixes Railway Docker build failure (TS2307: Cannot find module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)