### PR TITLE
Remove FMP from static fallback page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -455,7 +455,7 @@ eugene crypto BTCUSD
     </div>
 
     <footer>
-        eugene intelligence &mdash; SEC EDGAR + FMP + FRED &mdash; 17 extract types, 28 canonical concepts, 50+ financial ratios
+        eugene intelligence &mdash; SEC EDGAR + XBRL + FRED &mdash; 17 extract types, 28 canonical concepts, 50+ financial ratios
     </footer>
 
     <script>
@@ -481,7 +481,7 @@ eugene crypto BTCUSD
             btn.disabled = true;
             btn.textContent = 'Loading...';
             status.className = '';
-            status.textContent = 'Fetching data from SEC EDGAR + FMP...';
+            status.textContent = 'Fetching data from SEC EDGAR...';
             dashboard.classList.remove('active');
 
             try {


### PR DESCRIPTION
## Summary
- Remove FMP references from static/index.html (fallback landing page)
- FMP is an implementation detail, not user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)