### PR TITLE
Add news tab, auto-run screener, moat features

### DIFF
--- a/frontend/src/components/company/NewsSection.tsx
+++ b/frontend/src/components/company/NewsSection.tsx
@@ -1,0 +1,43 @@
+import type { NewsArticle } from '../../hooks/useNews';
+import { ExternalLink } from 'lucide-react';
+
+interface NewsSectionProps {
+  articles: NewsArticle[];
+}
+
+export function NewsSection({ articles }: NewsSectionProps) {
+  if (articles.length === 0) {
+    return <p className="py-8 text-center text-sm text-slate-400">No recent news found.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {articles.map((a, i) => (
+        <a
+          key={`${a.url}-${i}`}
+          href={a.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-lg border border-slate-200 p-4 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-900/50"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium leading-snug">{a.title}</p>
+              <div className="mt-1.5 flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+                <span>{a.source}</span>
+                <span>&middot;</span>
+                <span>{a.date}</span>
+              </div>
+              {a.snippet && (
+                <p className="mt-2 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                  {a.snippet}
+                </p>
+              )}
+            </div>
+            <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400" />
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNews.ts
+++ b/frontend/src/hooks/useNews.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { eugeneApi } from '../lib/api';
+
+export interface NewsArticle {
+  title: string;
+  date: string;
+  source: string;
+  url: string;
+  snippet?: string;
+  image?: string;
+}
+
+interface NewsResponse {
+  articles: NewsArticle[];
+  ticker: string;
+  source: string;
+}
+
+export function useNews(ticker: string) {
+  return useQuery<NewsResponse>({
+    queryKey: ['news', ticker],
+    queryFn: () => eugeneApi<NewsResponse>(`/v1/sec/${encodeURIComponent(ticker)}/news`),
+    enabled: !!ticker,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -8,6 +8,7 @@ import { useMetrics } from '../hooks/useMetrics';
 import { useFilings } from '../hooks/useFilings';
 import { useInsiders } from '../hooks/useInsiders';
 import { useSections } from '../hooks/useSections';
+import { useNews } from '../hooks/useNews';
 import { CompanyHeader } from '../components/company/CompanyHeader';
 import { PriceChart } from '../components/charts/PriceChart';
 import { FinancialStatements } from '../components/company/FinancialStatements';
@@ -15,12 +16,13 @@ import { MetricsGrid } from '../components/company/MetricsGrid';
 import { FilingsTable } from '../components/company/FilingsTable';
 import { InsidersTable } from '../components/company/InsidersTable';
 import { SectionsView } from '../components/company/SectionsView';
+import { NewsSection } from '../components/company/NewsSection';
 import { Tabs } from '../components/ui/Tabs';
 import { ProvenanceBar } from '../components/ui/Provenance';
 import { SkeletonCompanyHeader, SkeletonStatsGrid, SkeletonChart, SkeletonTable } from '../components/ui/Skeleton';
 import { formatPrice } from '../lib/utils';
 
-const PAGE_TABS = ['Overview', 'Financials', 'Metrics', 'Filings', 'Insiders', 'Sections'];
+const PAGE_TABS = ['Overview', 'Financials', 'Metrics', 'Filings', 'Insiders', 'News', 'Sections'];
 
 export function CompanyPage() {
   const { ticker = '' } = useParams();
@@ -35,6 +37,7 @@ export function CompanyPage() {
   const filings = useFilings(ticker);
   const insiders = useInsiders(ticker);
   const sections = useSections(ticker, sectionType);
+  const news = useNews(ticker);
 
   const isLoading = profile.isLoading || prices.isLoading;
   const error = profile.error || prices.error;
@@ -157,6 +160,14 @@ export function CompanyPage() {
             </>
           )}
           {insiders.error && <p className="text-sm text-red-500">Failed to load insider data</p>}
+        </div>
+      )}
+
+      {tab === 'News' && (
+        <div>
+          {news.isLoading && <SkeletonTable rows={6} cols={1} />}
+          {news.data?.articles && <NewsSection articles={news.data.articles} />}
+          {news.error && <p className="text-sm text-red-500">Failed to load news</p>}
         </div>
       )}
 

--- a/frontend/src/pages/ScreenerPage.tsx
+++ b/frontend/src/pages/ScreenerPage.tsx
@@ -6,7 +6,7 @@ import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 
 export function ScreenerPage() {
   const [filters, setFilters] = useState<Filters>({ limit: 50 });
-  const [submitted, setSubmitted] = useState(false);
+  const [submitted, setSubmitted] = useState(true);
   const { data, isLoading, error } = useScreener(filters, submitted);
 
   const note = data?.note;


### PR DESCRIPTION
## Summary
- News tab on company page with article cards (title, source, date, snippet, external link)
- Screener auto-runs on page load instead of requiring manual "Screen Stocks" click
- useNews hook + NewsSection component

## Test plan
- [ ] /company/AAPL shows News tab with articles
- [ ] /screener loads results automatically
- [ ] All existing tabs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)