### PR TITLE
Fix: add anthropic dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ click>=8.0.0,<9
 python-dotenv>=1.0.0,<2
 httpx>=0.24,<1
 rich>=13.0,<15
+anthropic>=0.30.0,<1


### PR DESCRIPTION
## Summary
- Add `anthropic` package to requirements.txt — needed for the research agent
- Previous deploy failed because the import wasn't available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)