### PR TITLE
Add feedback widget and /v1/feedback endpoint

### DIFF
--- a/eugene_server.py
+++ b/eugene_server.py
@@ -198,6 +198,34 @@ def _build_mcp(include_rest: bool = False):
             except Exception:
                 return JSONResponse({"error": "Failed to process request"}, status_code=500)
 
+        @mcp.custom_route("/v1/feedback", methods=["POST"])
+        async def feedback(request: Request) -> JSONResponse:
+            """Collect user feedback and feature requests."""
+            import json as _json
+            import pathlib
+            try:
+                body = await request.body()
+                data = _json.loads(body)
+                fb_type = data.get("type", "feedback")  # feedback, feature, bug
+                message = data.get("message", "").strip()
+                email = data.get("email", "").strip()
+                page = data.get("page", "")
+                if not message or len(message) < 5:
+                    return JSONResponse({"error": "Message too short"}, status_code=400)
+                fb_file = pathlib.Path("feedback.jsonl")
+                entry = {
+                    "type": fb_type,
+                    "message": message[:2000],
+                    "email": email if email and "@" in email else None,
+                    "page": page,
+                    "ts": __import__("datetime").datetime.utcnow().isoformat(),
+                }
+                with open(fb_file, "a") as f:
+                    f.write(_json.dumps(entry) + "\n")
+                return JSONResponse({"status": "ok", "message": "Thank you for your feedback!"})
+            except Exception:
+                return JSONResponse({"error": "Failed to process request"}, status_code=500)
+
         @mcp.custom_route("/health", methods=["GET"])
         async def health(request: Request) -> JSONResponse:
             return JSONResponse({"status": "ok", "version": VERSION})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { EconomicsPage } from './pages/EconomicsPage';
 import { DocsPage } from './pages/DocsPage';
 import { PricingPage } from './pages/PricingPage';
 import { NotFoundPage } from './pages/NotFoundPage';
+import { FeedbackWidget } from './components/ui/FeedbackWidget';
 
 const PAGE_TITLES: Record<string, string> = {
   '/': 'Eugene Intelligence',
@@ -55,6 +56,7 @@ export default function App() {
           </Routes>
         </main>
         <Footer />
+        <FeedbackWidget />
       </div>
     </BrowserRouter>
   );

--- a/frontend/src/components/ui/FeedbackWidget.tsx
+++ b/frontend/src/components/ui/FeedbackWidget.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { MessageSquarePlus, X, Send, Bug, Lightbulb, MessageCircle } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const TYPES = [
+  { key: 'feedback', label: 'Feedback', icon: MessageCircle },
+  { key: 'feature', label: 'Feature Request', icon: Lightbulb },
+  { key: 'bug', label: 'Bug Report', icon: Bug },
+] as const;
+
+export function FeedbackWidget() {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<string>('feedback');
+  const [message, setMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim() || message.trim().length < 5) return;
+
+    setStatus('sending');
+    try {
+      const res = await fetch('/v1/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type,
+          message: message.trim(),
+          email: email.trim(),
+          page: window.location.pathname,
+        }),
+      });
+      if (res.ok) {
+        setStatus('sent');
+        setTimeout(() => {
+          setOpen(false);
+          setStatus('idle');
+          setMessage('');
+          setEmail('');
+          setType('feedback');
+        }, 2000);
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  return (
+    <>
+      {/* Floating button */}
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-transform hover:scale-105 hover:bg-blue-700"
+        aria-label="Send feedback"
+      >
+        <MessageSquarePlus className="h-5 w-5" />
+      </button>
+
+      {/* Modal overlay */}
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end justify-end p-6 sm:items-center sm:justify-center">
+          <div className="fixed inset-0 bg-black/40" onClick={() => setOpen(false)} />
+          <div className="relative w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900">
+            {/* Header */}
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-semibold">Share your feedback</h3>
+              <button
+                onClick={() => setOpen(false)}
+                className="rounded-md p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {status === 'sent' ? (
+              <div className="py-8 text-center">
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30">
+                  <Send className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                </div>
+                <p className="font-medium">Thank you!</p>
+                <p className="mt-1 text-sm text-slate-500">Your feedback helps us build a better product.</p>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Type selector */}
+                <div className="flex gap-2">
+                  {TYPES.map(({ key, label, icon: Icon }) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setType(key)}
+                      className={cn(
+                        'flex flex-1 items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-medium transition-colors',
+                        type === key
+                          ? 'border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950/50 dark:text-blue-300'
+                          : 'border-slate-200 text-slate-500 hover:border-slate-300 dark:border-slate-700 dark:text-slate-400'
+                      )}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Message */}
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder={
+                    type === 'feature'
+                      ? 'Describe the feature you would like to see...'
+                      : type === 'bug'
+                        ? 'What went wrong? Steps to reproduce...'
+                        : 'What do you think? How can we improve?'
+                  }
+                  className="w-full rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700"
+                  rows={4}
+                  required
+                  minLength={5}
+                />
+
+                {/* Email (optional) */}
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Email (optional — for follow-up)"
+                  className="w-full rounded-lg border border-slate-200 bg-transparent px-3 py-2 text-sm placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700"
+                />
+
+                {/* Submit */}
+                <div className="flex items-center justify-between">
+                  {status === 'error' && (
+                    <p className="text-xs text-red-500">Failed to send. Try again.</p>
+                  )}
+                  <div className="flex-1" />
+                  <button
+                    type="submit"
+                    disabled={status === 'sending' || message.trim().length < 5}
+                    className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    <Send className="h-3.5 w-3.5" />
+                    {status === 'sending' ? 'Sending...' : 'Send'}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a floating feedback button (bottom-right) on all pages that opens a modal for submitting feedback, feature requests, or bug reports
- Backend POST `/v1/feedback` endpoint stores submissions to `feedback.jsonl`
- Modal includes type selector, message textarea, and optional email field

## Test plan
- [ ] Click floating blue button → modal opens
- [ ] Select each feedback type (Feedback, Feature Request, Bug Report)
- [ ] Submit with message → shows "Thank you!" confirmation
- [ ] Verify `feedback.jsonl` receives entries on server

🤖 Generated with [Claude Code](https://claude.com/claude-code)