### PR TITLE
Fix Docker build: add Rust toolchain for native deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Install build tools for native extensions (rpds-py needs Rust)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cargo rustc \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Python dependencies first for layer caching
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
- PR #25 deploy failed because `rpds-py` (transitive dep from `mcp` → `jsonschema`) needs Rust to compile on `python:3.12-slim`
- Adds `build-essential`, `cargo`, and `rustc` to the Docker build stage

## Test plan
- [ ] Railway build succeeds
- [ ] All endpoints work (research agent, feedback, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)