### PR TITLE
Fix TypeScript build error in useSections

### DIFF
--- a/frontend/src/hooks/useSections.ts
+++ b/frontend/src/hooks/useSections.ts
@@ -40,7 +40,7 @@ export function useSections(ticker: string, section?: string) {
     queryFn: async () => {
       const params = new URLSearchParams({ extract: 'sections', limit: '5' });
       if (section) params.set('section', section);
-      const raw = await fetchSEC<RawSectionsData>(ticker, params);
+      const raw = await fetchSEC<EugeneResponse<RawSectionsData>>(ticker, params);
       return transformSections(raw);
     },
     enabled: !!ticker,


### PR DESCRIPTION
## Summary
- Fixes TS2345 error: `fetchSEC<RawSectionsData>` returns `RawSectionsData` but `transformSections` expects `EugeneResponse<RawSectionsData>`
- Changed to `fetchSEC<EugeneResponse<RawSectionsData>>` to match the actual API envelope shape
- Verified: `tsc -b` passes, `npm run build` succeeds

## Test plan
- [ ] Railway build succeeds
- [ ] Sections tab on company page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)