### PR TITLE
Fix lint error and simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install build tools for native extensions (rpds-py needs Rust)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential cargo rustc \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install Python dependencies first for layer caching
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --prefer-binary -r requirements.txt
 
 # Copy application source and install the package
 COPY . .

--- a/eugene/research.py
+++ b/eugene/research.py
@@ -12,8 +12,6 @@ import json
 import logging
 import time
 from collections import defaultdict
-from typing import Optional
-
 from eugene.cache import cached
 from eugene.config import get_config
 from eugene.router import query


### PR DESCRIPTION
## Summary
- Remove unused `Optional` import in `research.py` (fixes ruff CI failure)
- Replace Rust toolchain install with `--prefer-binary` pip flag (faster builds, smaller image)

## Test plan
- [ ] CI lint passes
- [ ] Railway build succeeds
- [ ] Research endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)