### PR TITLE
Fix failing CI tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ class TestAPIConfig:
         assert cfg.fred_api_key is None
         assert cfg.fmp_api_key is None
         assert cfg.anthropic_api_key is None
-        assert cfg.anthropic_model == "claude-sonnet-4-20250514"
+        assert cfg.anthropic_model == "claude-haiku-4-5-20251001"
 
     def test_env_loading(self):
         env = {"FRED_API_KEY": "fred123", "FMP_API_KEY": "fmp456", "ANTHROPIC_API_KEY": "ant789"}

--- a/tests/test_handlers_sec.py
+++ b/tests/test_handlers_sec.py
@@ -340,7 +340,14 @@ class TestSectionsHandler:
         mock_html.return_value = """
         <html><body>
         <h2>Item 7. Management's Discussion and Analysis</h2>
-        <p>We had a great year with record revenue growth across all segments.</p>
+        <p>We had a great year with record revenue growth across all segments.
+        Our total revenue increased 15 percent year-over-year to $394.3 billion,
+        driven by strong performance in our Services segment which grew 24 percent
+        to reach $85.2 billion. Gross margin expanded 120 basis points to 46.2 percent
+        as we benefited from favorable product mix and cost efficiencies in our supply
+        chain. Operating expenses were well-controlled, growing only 8 percent while
+        we continued to invest heavily in research and development initiatives across
+        artificial intelligence and machine learning capabilities.</p>
         <h2>Item 8. Financial Statements</h2>
         </body></html>
         """


### PR DESCRIPTION
## Summary
- Update `test_defaults` to expect `claude-haiku-4-5-20251001` (matches config change from PR #23)
- Add sufficient content to `test_sections_mdna` HTML fixture (handler has 200-char minimum guard)

## Test plan
- [x] Both tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)